### PR TITLE
Check license

### DIFF
--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -376,6 +376,9 @@ function New-CSideDevContainer {
     if (!(Test-Path $licenseFile)) {
         throw "License file '$licenseFile' must exist in order to create a Developer Server Container."
     }
+    if (!($licenseFile.Contains($demoFolder))) {
+        throw "License file '$licenseFile' must be placed in $demoFolder folder or any of its subfolders and referenced using full-path format."
+    }
     $containerLicenseFile = $licenseFile.Replace("$demoFolder\", "$containerDemoFolder\")
 
     if ($devImageName -eq "") {


### PR DESCRIPTION
 - The license must be placed inside the script root filesystem.
 - Solution for Microsoft/nav-docker#75