### PR TITLE
SQLCMD fails on named pipes, changed to TCP

### DIFF
--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -836,7 +836,7 @@ function New-NavContainer {
         $programFilesFolder = Join-Path $containerFolder "Program Files"
         New-Item -Path $programFilesFolder -ItemType Directory -ErrorAction Ignore | Out-Null
 
-        'sqlcmd -d $DatabaseName -Q "update [dbo].[Object] SET [Modified] = 0"
+        'sqlcmd -S tcp:127.0.0.1\sqlexpress -d $DatabaseName -Q "update [dbo].[Object] SET [Modified] = 0"
         ' | Add-Content -Path "$myfolder\AdditionalSetup.ps1"
         
         if (Test-Path $programFilesFolder) {


### PR DESCRIPTION
SQLCMD consistently fails to connect on my W10 laptop when trying to use named pipes. Even when using Enter-NavContainer and trying to run the same SQLCMD from the PS prompt inside the container it does not succeed to connect. When I force SQLCMD to connect through TCP the script runs and continues successfully. 

When the SQL connection fails, many things after this command also fail (creation of desktop shortcuts, export of objects, etc...). The container does reach healthy status however and everything else seems to working OK.

sqlcmd : Sqlcmd: Error: Microsoft ODBC Driver 13 for SQL Server : Named Pipes Provider: Could not open a connection to SQL Server [2]. .
    + CategoryInfo          : NotSpecified: (Sqlcmd: Error: ...L Server [2]. .:String) [], RemoteException
    + FullyQualifiedErrorId : NativeCommandError
 
Sqlcmd: Error: Microsoft ODBC Driver 13 for SQL Server : Login timeout expired.
Sqlcmd: Error: Microsoft ODBC Driver 13 for SQL Server : A network-related or instance-specific error has occurred while establishing a connection to SQL Server. Server is not found or not accessible. Check if instance name is correct and if SQL Server is config
ured to allow remote connections. For more information see SQL Server Books Online..
