### PR TITLE
Show container name in prompt when in remote session

### DIFF
--- a/ContainerHandling/Enter-NavContainer.ps1
+++ b/ContainerHandling/Enter-NavContainer.ps1
@@ -22,6 +22,9 @@ function Enter-NavContainer {
     Process {
         $session = Get-NavContainerSession $containerName
         Enter-PSSession -Session $session
+        Invoke-Command -Session $session -ScriptBlock {
+            function prompt {"[$env:COMPUTERNAME]: PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "}
+        }
     }
 }
 Export-ModuleMember -function Enter-NavContainer


### PR DESCRIPTION
Instead of having a prompt like this:

`[50f1bdc0752b173da826a718e20d3c4d08a041d9a0924f7f39cc221ea9137e22]: PS C:\run>`

this looks way better:

`[NAVDEMO]: PS C:\run>`