### PR TITLE
Use settings file for RTC client desktop shortcut

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -413,7 +413,7 @@ function New-NavContainer {
 
     if ($includeCSide) {
         $winClientFolder = (Get-Item "$programFilesFolder\*\RoleTailored Client").FullName
-        New-DesktopShortcut -Name "$containerName Windows Client" -TargetPath "$WinClientFolder\Microsoft.Dynamics.Nav.Client.exe" -Shortcuts $shortcuts
+        New-DesktopShortcut -Name "$containerName Windows Client" -TargetPath "$WinClientFolder\Microsoft.Dynamics.Nav.Client.exe" -Arguments "-settings:ClientUserSettings.config" -Shortcuts $shortcuts
 
         $databaseInstance = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseInstance']").Value
         $databaseName = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value


### PR DESCRIPTION
To prevent the RTC client from using the shared **clientusersettings.config** file (in _%appdata%\Microsoft\Microsoft Dynamics NAV\110_), 
we should provide the argument **-settings:ClientUserSettings.config**.
This way the shortcut always works even when working with multiple containers on the same machine.