### PR TITLE
Added possibility to choose which tenant database to export when exporting bacpacs

### DIFF
--- a/Bacpac/Export-NavContainerDatabasesAsBacpac.ps1
+++ b/Bacpac/Export-NavContainerDatabasesAsBacpac.ps1
@@ -10,12 +10,17 @@
   Credentials for the SQL admin user if using NavUserPassword authentication. User will be prompted if not provided
  .Parameter bacpacFolder
   The folder to which the bacpac files are exported (needs to be shared with the container)
+ .Parameter tenantDatabaseToExport
+  The tenant database to export, only applies to multi-tenant containers.
+  Default is the mounted tenant, tenant is the template tenant.
  .Example
   Export-NavContainerDatabasesAsBacpac -containerName test
  .Example
   Export-NavContainerDatabasesAsBacpac -containerName test -bacpacfolder "c:\programdata\navcontainerhelper\extensions\test"
  .Example
   Export-NavContainerDatabasesAsBacpac -containerName test -bacpacfolder "c:\demo" -sqlCredential <sqlCredential>
+ .Example
+  Export-NavContainerDatabasesAsBacpac -containerName test -tenantDatabaseToExport Default
 #>
 function Export-NavContainerDatabasesAsBacpac {
     Param(
@@ -24,7 +29,10 @@ function Export-NavContainerDatabasesAsBacpac {
         [Parameter(Mandatory=$false)]
         [System.Management.Automation.PSCredential]$sqlCredential = $null,
         [Parameter(Mandatory=$false)]
-        [string]$bacpacFolder = ""
+        [string]$bacpacFolder = "",
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("Tenant","Default")]
+        [string]$tenantDatabaseToExport="Tenant"
     )
     
     $genericTag = Get-NavContainerGenericTag -containerOrImageName $containerName
@@ -41,7 +49,7 @@ function Export-NavContainerDatabasesAsBacpac {
     $containerBacpacFolder = Get-NavContainerPath -containerName $containerName -path $bacpacFolder -throw
 
     $session = Get-NavContainerSession -containerName $containerName -silent
-    Invoke-Command -Session $session -ScriptBlock { Param($sqlCredential, $bacpacFolder)
+    Invoke-Command -Session $session -ScriptBlock { Param($sqlCredential, $bacpacFolder, $tenantDatabaseToExport)
     
         function Install-DACFx
         {
@@ -217,7 +225,7 @@ function Export-NavContainerDatabasesAsBacpac {
             
             $tempTenantDatabaseName = "tempTenant"
             $tenantBacpacFileName = Join-Path $bacpacFolder "tenant.bacpac"
-            Copy-NavDatabase -SourceDatabaseName "tenant" -DestinationDatabaseName $tempTenantDatabaseName
+            Copy-NavDatabase -SourceDatabaseName $tenantDatabaseToExport -DestinationDatabaseName $tempTenantDatabaseName
             Remove-NavTenantDatabaseUserData -DatabaseServer $databaseServer -DatabaseName $tempTenantDatabaseName -sqlCredential $sqlCredential
             Do-Export -DatabaseServer $databaseServer -DatabaseName $tempTenantDatabaseName -sqlCredential $sqlCredential -targetFile $tenantBacpacFileName
         } else {
@@ -228,7 +236,7 @@ function Export-NavContainerDatabasesAsBacpac {
             Remove-NavTenantDatabaseUserData -DatabaseServer $databaseServer -DatabaseName $tempDatabaseName -sqlCredential $sqlCredential
             Do-Export -DatabaseServer $databaseServer -DatabaseName $tempDatabaseName -sqlCredential $sqlCredential -targetFile $bacpacFileName
         }
-    } -ArgumentList $sqlCredential, $containerBacpacFolder
+    } -ArgumentList $sqlCredential, $containerBacpacFolder, $tenantDatabaseToExport
 }
 Export-ModuleMember Export-NavContainerDatabasesAsBacpac
 


### PR DESCRIPTION
By default the database 'tenant' is being exported - this is the template tenant.
Any changes done in the container (Default database) are never included in the exported tenant bacpac.

In our case we want to maintain our setup/sample data in a Docker container and at some point export this data and use it for new deployments.

Note: this only applies to multi-tenant containers.