### PR TITLE
[Bugfix] Create-AadAppsForNav - Get-AzureADUser only retrieves the first 100 users.

### DIFF
--- a/AzureAD/Create-AadAppsForNav.ps1
+++ b/AzureAD/Create-AadAppsForNav.ps1
@@ -64,7 +64,7 @@ function Create-AadAppsForNav
     $aadTenant = $account.TenantId
     $AdProperties["AadTenant"] = $AadTenant
 
-    $adUser = get-azureaduser | Where-Object { $_.UserPrincipalName -eq $aadadmincredential.UserName }
+    $adUser = Get-AzureADUser -ObjectId $aadadmincredential.UserName
     if (!$adUser) {
         throw "Could not identify Aad Tenant"
     }


### PR DESCRIPTION
Get-AzureADUser only retrieves the first 100 users, if you're unlucky you're outside those 100 users, this causes an error.

Can be solved in two ways:
- Add the -All $true parameter to the Get-AzureADUser cmdlet.
- Filter up front by using the -ObjectId parameter so that it only retrieves that specific user instead of all the users.

I implemented the latter.