### PR TITLE
Added support for "Version" in sync, publish, install & uninstall Nav…

### DIFF
--- a/AppHandling/Install-NavContainerApp.ps1
+++ b/AppHandling/Install-NavContainerApp.ps1
@@ -26,7 +26,16 @@ function Install-NavContainerApp {
     $session = Get-NavContainerSession -containerName $containerName
     Invoke-Command -Session $session -ScriptBlock { Param($appName, $appVersion, $tenant)
         Write-Host "Installing $appName on $tenant"
-        Install-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant
+        $parameters = @{ 
+            "ServerInstance" = "NAV";
+            "Name" = $appName; 
+            "Tenant" = $tenant
+        }
+        if ($appVersion)
+        {
+            $parameters += @{ "Version" = $appVersion }
+        }
+        Install-NavApp @parameters
     } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully installed"
 }

--- a/AppHandling/Install-NavContainerApp.ps1
+++ b/AppHandling/Install-NavContainerApp.ps1
@@ -19,7 +19,7 @@ function Install-NavContainerApp {
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
         [string]$appName,
-        [Parameter]
+        [Parameter()]
         [string]$appVersion
     )
 

--- a/AppHandling/Install-NavContainerApp.ps1
+++ b/AppHandling/Install-NavContainerApp.ps1
@@ -18,14 +18,16 @@ function Install-NavContainerApp {
         [Parameter(Mandatory=$false)]
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
-        [string]$appName
+        [string]$appName,
+        [Parameter]
+        [string]$appVersion
     )
 
     $session = Get-NavContainerSession -containerName $containerName
-    Invoke-Command -Session $session -ScriptBlock { Param($appName, $tenant)
+    Invoke-Command -Session $session -ScriptBlock { Param($appName, $appVersion, $tenant)
         Write-Host "Installing $appName on $tenant"
-        Install-NavApp -ServerInstance NAV -Name $appName -Tenant $tenant
-    } -ArgumentList $appName, $tenant
+        Install-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant
+    } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully installed"
 }
 Export-ModuleMember -Function Install-NavContainerApp

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -67,16 +67,17 @@ function Publish-NavContainerApp {
         Publish-NavApp -ServerInstance NAV -Path $appFile -SkipVerification:$SkipVerification -packageType $packageType
         if ($sync -or $install) {
             $appName = (Get-NAVAppInfo -Path $appFile).Name
+            $appVersion = (Get-NAVAppInfo -Path $appFile).Version
     
             if ($sync) {
                 Write-Host "Synchronizing $appName on tenant $tenant"
                 Sync-NavTenant -ServerInstance NAV -Tenant $tenant -Force
-                Sync-NavApp -ServerInstance NAV -Name $appName -Tenant $tenant -WarningAction Ignore
+                Sync-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant -WarningAction Ignore
             }
     
             if ($install) {
                 Write-Host "Installing $appName on tenant $tenant"
-                Install-NavApp -ServerInstance NAV -Name $appName -Tenant $tenant
+                Install-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant
             }
         }
 

--- a/AppHandling/Start-NavContainerAppDataUpgrade.ps1
+++ b/AppHandling/Start-NavContainerAppDataUpgrade.ps1
@@ -12,16 +12,30 @@
 #>
 function  Start-NavContainerAppDataUpgrade {
     Param(
+        [Parameter(Mandatory=$false)]
+        [string]$containerName = "navserver",
+        [Parameter(Mandatory=$false)]
+        [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
         [string]$appName,
-        [string]$containerName = "navserver"
+        [Parameter()]
+        [string]$appVersion
     )
 
     $session = Get-NavContainerSession -containerName $containerName
-    Invoke-Command -Session $session -ScriptBlock { Param($appName)
+    Invoke-Command -Session $session -ScriptBlock { Param($appName, $appVersion, $tenant)
         Write-Host "Upgrading app $appName"
-        Start-NAVAppDataUpgrade -ServerInstance NAV -Name $appName
-    } -ArgumentList $appName
+        $parameters = @{
+            "ServerInstance" = "NAV";
+            "Name" = $appName;
+            "Tenant" = $tenant
+        }
+        if ($appVersion)
+        {
+            $parameters += @{ "Version" = $appVersion }
+        }
+        Start-NAVAppDataUpgrade @parameters
+    } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully upgraded"
 }
 Export-ModuleMember -Function Start-NavContainerAppDataUpgrade

--- a/AppHandling/Sync-NavContainerApp.ps1
+++ b/AppHandling/Sync-NavContainerApp.ps1
@@ -25,7 +25,16 @@ function Sync-NavContainerApp {
     Invoke-Command -Session $session -ScriptBlock { Param($appName,$appVersion,$tenant)
         Write-Host "Synchronizing $appFile on $tenant"
         Sync-NavTenant -ServerInstance NAV -Tenant $tenant -Force
-        Sync-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant
+        $parameters = @{
+            "ServerInstance" = "NAV";
+            "Name" = $appName;
+            "Tenant" = $tenant
+        }
+        if ($appVersion)
+        {
+            $parameters += @{ "Version" = $appVersion }
+        }
+        Sync-NavApp @parameters
     } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully synchronized"
 }

--- a/AppHandling/Sync-NavContainerApp.ps1
+++ b/AppHandling/Sync-NavContainerApp.ps1
@@ -18,7 +18,7 @@ function Sync-NavContainerApp {
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
         [string]$appName,
-        [Parameter]
+        [Parameter()]
         [string]$appVersion
     )
     $session = Get-NavContainerSession -containerName $containerName

--- a/AppHandling/Sync-NavContainerApp.ps1
+++ b/AppHandling/Sync-NavContainerApp.ps1
@@ -17,14 +17,16 @@ function Sync-NavContainerApp {
         [Parameter(Mandatory=$false)]
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
-        [string]$appName
+        [string]$appName,
+        [Parameter]
+        [string]$appVersion
     )
     $session = Get-NavContainerSession -containerName $containerName
-    Invoke-Command -Session $session -ScriptBlock { Param($appName,$tenant)
+    Invoke-Command -Session $session -ScriptBlock { Param($appName,$appVersion,$tenant)
         Write-Host "Synchronizing $appFile on $tenant"
         Sync-NavTenant -ServerInstance NAV -Tenant $tenant -Force
-        Sync-NavApp -ServerInstance NAV -Name $appName -Tenant $tenant
-    } -ArgumentList $appName, $tenant
+        Sync-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant
+    } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully synchronized"
 }
 Export-ModuleMember -Function Sync-NavContainerApp

--- a/AppHandling/UnInstall-NavContainerApp.ps1
+++ b/AppHandling/UnInstall-NavContainerApp.ps1
@@ -25,7 +25,16 @@ function UnInstall-NavContainerApp {
     $session = Get-NavContainerSession -containerName $containerName
     Invoke-Command -Session $session -ScriptBlock { Param($appName, $appVersion, $tenant)
         Write-Host "Uninstalling $appName from $tenant"
-        Uninstall-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -tenant $tenant
+        $parameters = @{
+            "ServerInstance" = "NAV";
+            "Name" = $appName;
+            "Tenant" = $tenant
+        }
+        if ($appVersion)
+        {
+            $parameters += @{ "Version" = $appVersion }
+        }
+        Uninstall-NavApp @parameters
     } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully uninstalled"
 }

--- a/AppHandling/UnInstall-NavContainerApp.ps1
+++ b/AppHandling/UnInstall-NavContainerApp.ps1
@@ -18,7 +18,7 @@ function UnInstall-NavContainerApp {
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
         [string]$appName,
-        [Parameter]
+        [Parameter()]
         [string]$appVersion
     )
 

--- a/AppHandling/UnInstall-NavContainerApp.ps1
+++ b/AppHandling/UnInstall-NavContainerApp.ps1
@@ -17,14 +17,16 @@ function UnInstall-NavContainerApp {
         [Parameter(Mandatory=$false)]
         [string]$tenant = "default",
         [Parameter(Mandatory=$true)]
-        [string]$appName
+        [string]$appName,
+        [Parameter]
+        [string]$appVersion
     )
 
     $session = Get-NavContainerSession -containerName $containerName
-    Invoke-Command -Session $session -ScriptBlock { Param($appName, $tenant)
+    Invoke-Command -Session $session -ScriptBlock { Param($appName, $appVersion, $tenant)
         Write-Host "Uninstalling $appName from $tenant"
-        Uninstall-NavApp -ServerInstance NAV -Name $appName -tenant $tenant
-    } -ArgumentList $appName, $tenant
+        Uninstall-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -tenant $tenant
+    } -ArgumentList $appName, $appVersion, $tenant
     Write-Host -ForegroundColor Green "App successfully uninstalled"
 }
 Export-ModuleMember -Function UnInstall-NavContainerApp


### PR DESCRIPTION
Installing multiple versions of the same app does not seem to be supported. So now "Publish-NavContainerApp" reads the version from the app and passes it along to Sync / Install. Synch / Install / and UnInstall-NavContainerApp now support an optional parameter "appVersion".