### PR TITLE
Bugfixes

### DIFF
--- a/AzureAD/Create-AadUsersInNavContainer.ps1
+++ b/AzureAD/Create-AadUsersInNavContainer.ps1
@@ -51,11 +51,12 @@ function Create-AadUsersInNavContainer
     $account = Connect-AzureAD -Credential $AadAdminCredential
     Get-AzureADUser -All $true | Where-Object { $_.AccountEnabled } | ForEach-Object {
         $userName = $_.MailNickName
-        if (Get-NavContainerNavUser -containerName $containerName -tenant $tenant | Where-Object { $_.UserName -eq $userName }) {
+        $authenticationEMail = $_.UserPrincipalName
+        if (Get-NavContainerNavUser -containerName $containerName -tenant $tenant | Where-Object { $_.UserName -eq $userName -or $_.AuthenticationEmail -eq $authenticationEMail }) {
             Write-Host "User $userName already exists"
         } else {
             $Credential = [System.Management.Automation.PSCredential]::new($userName, $securePassword)
-            New-NavContainerNavUser -containerName $containerName -tenant $tenant -AuthenticationEmail $_.UserPrincipalName -Credential $Credential -PermissionSetId $permissionSetId -ChangePasswordAtNextLogOn $ChangePasswordAtNextLogOn
+            New-NavContainerNavUser -containerName $containerName -tenant $tenant -AuthenticationEmail $authenticationEMail -Credential $Credential -PermissionSetId $permissionSetId -ChangePasswordAtNextLogOn $ChangePasswordAtNextLogOn
         }
     }
 }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,13 @@
+0.3.1.5
+BugFix #207: Compile-AppInNavContainer is downloading symbols for app which is in the AppSymbolFolder
+Include timezone parameter on Invoke-NavContainerCodeunit
+Compile-AppInNavContainer checks existance of dependencies in app.json
+Use .alpackages as default symbols folder
+BugFix #216: enableSymbolLoading only works with includeCSide
+BugFix #215: Naming symbol-files when compiling with Compile-AppInNavContainer
+Display progress when pulling and avoid deadlocks when running using New-NavContainer
+Bugfix Get-AzureADUser didn''t always retrieve the user needed
+
 0.3.1.4
 BugFix Convert-ModifiedObjectsToAl failed after the newly introduced [LineStart()] property in newsyntax export
 

--- a/UserHandling/Setup-NavContainerTestUsers.ps1
+++ b/UserHandling/Setup-NavContainerTestUsers.ps1
@@ -57,6 +57,7 @@ Param
     $fobfile = Join-Path $env:TEMP "CreateTestUsers.fob"
     Download-File -sourceUrl "http://aka.ms/createtestusersfob" -destinationFile $fobfile
     Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile -sqlCredential $sqlCredential
+    Start-Sleep -Seconds 5
     Invoke-NavContainerCodeunit -containerName $containerName -tenant $tenant -CodeunitId 50000 -MethodName CreateTestUsers -Argument ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)))
 }
 Export-ModuleMember -Function Setup-NavContainerTestUsers


### PR DESCRIPTION
Use .alpackages as default symbols folder
BugFix #215: Naming symbol-files when compiling with Compile-AppInNavContainer
Bugfix Get-AzureADUser didn''t always retrieve the user needed