### PR TITLE
Added support for "TenantSpecificProperties" in Get-NavContainerAppInfo

### DIFF
--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -17,11 +17,11 @@ function Get-NavContainerAppInfo {
         
         [Parameter(Mandatory = $false)]
         [switch]
-        $TenantSpecificProperties,
+        $tenantSpecificProperties,
         
         [Parameter(Mandatory = $false)]
         [String]
-        $Tenant
+        $tenant
     )
 
     $args = @{
@@ -30,12 +30,12 @@ function Get-NavContainerAppInfo {
     if ($symbolsOnly) {
         $args += @{ SymbolsOnly = $true }
     }
-    if ($TenantSpecificProperties) {
-        if ("$Tenant" -eq "") {
-            $Tenant = "default"
+    if ($tenantSpecificProperties) {
+        if ("$tenant" -eq "") {
+            $tenant = "default"
         }
          
-        $args += @{ Tenant = $Tenant }
+        $args += @{ Tenant = $tenant }
         $args += @{ TenantSpecificProperties = $true }
     }
 

--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -13,12 +13,38 @@
 function Get-NavContainerAppInfo {
     Param(
         [string]$containerName = "navserver",
-        [switch]$symbolsOnly
+        [switch]$symbolsOnly,
+        
+        [Parameter(Mandatory = $false)]
+        [switch]
+        $TenantSpecificProperties,
+        
+        [Parameter(Mandatory = $false)]
+        [String]
+        $Tenant
     )
 
+    $args = @{
+        ServerInstance = "NAV"
+    }
+    if ($symbolsOnly) {
+        $args += @{ SymbolsOnly = $true }
+    }
+    if ($TenantSpecificProperties) {
+        if ("$Tenant" -eq "") {
+            $Tenant = "default"
+        }
+         
+        $args += @{ Tenant = $Tenant }
+        $args += @{ TenantSpecificProperties = $true }
+    }
+
     $session = Get-NavContainerSession -containerName $containerName
-    Invoke-Command -Session $session -ScriptBlock { Param($symbolsOnly)
-        Get-NavAppInfo -ServerInstance NAV -SymbolsOnly:$symbolsOnly
-    } -ArgumentList $symbolsOnly
+    Invoke-Command -Session $session -ScriptBlock { 
+        param(
+            $inArgs
+        )
+        Get-NavAppInfo @inArgs
+    } -ArgumentList $args
 }
 Export-ModuleMember -Function Get-NavContainerAppInfo


### PR DESCRIPTION
Just as the title says.

Btw: I don't know if you prefer the notation **t**enantSpecificProperties  over **T**enantSpecificProperties. I usually use uppercase, but you mostly use camelCase, so I changed that.