### PR TITLE
Add parameters scope and syncMode

### DIFF
--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -12,12 +12,16 @@
   Include this parameter if the app you want to publish is not signed
  .Parameter sync
   Include this parameter if you want to synchronize the app after publishing
+  .Parameter syncMode
+   Specify Add, Clean or Development based on how you want to synchronize the database schema. Default is Add
  .Parameter install
   Include this parameter if you want to install the app after publishing
  .Parameter tenant
   If you specify the install switch, then you can specify the tenant in which you want to install the app
  .Parameter packageType
-  Specify Extension or SymbolsOnly based on which package yu 
+  Specify Extension or SymbolsOnly based on which package you want to publish
+ .Parameter scope
+  Specify Global or Tenant based on how you want to publish the package. Default is Global
  .Example
   Publish-NavContainerApp -appFile c:\temp\myapp.app
  .Example
@@ -34,11 +38,15 @@ function Publish-NavContainerApp {
         [string]$appFile,
         [switch]$skipVerification,
         [switch]$sync,
+        [ValidateSet('Add','Clean','Development')]
+        [string]$syncMode = 'Add',
         [switch]$install,
         [Parameter(Mandatory=$false)]
         [string]$tenant = "default",
         [ValidateSet('Extension','SymbolsOnly')]
-        [string]$packageType = 'Extension'
+        [string]$packageType = 'Extension',
+        [ValidateSet('Global','Tenant')]
+        [string]$scope = 'Global'
     )
 
     $copied = $false
@@ -54,7 +62,7 @@ function Publish-NavContainerApp {
     }
 
     $session = Get-NavContainerSession -containerName $containerName -silent
-    Invoke-Command -Session $session -ScriptBlock { Param($appFile, $skipVerification, $copied, $sync, $install, $tenant, $packageType)
+    Invoke-Command -Session $session -ScriptBlock { Param($appFile, $skipVerification, $copied, $sync, $install, $tenant, $packageType, $scope, $syncMode)
 
         if ($appFile.ToLower().StartsWith("http://") -or $appFile.ToLower().StartsWith("https://")) {
             $appUrl = $appFile
@@ -64,14 +72,18 @@ function Publish-NavContainerApp {
         }
 
         Write-Host "Publishing $appFile"
-        Publish-NavApp -ServerInstance NAV -Path $appFile -SkipVerification:$SkipVerification -packageType $packageType
+        if ($scope -eq 'Tenant') {
+          Publish-NavApp -ServerInstance NAV -Path $appFile -SkipVerification:$SkipVerification -packageType $packageType -Scope $scope -Tenant $tenant
+        } else {
+            Publish-NavApp -ServerInstance NAV -Path $appFile -SkipVerification:$SkipVerification -packageType $packageType -Scope $scope
+        }
         if ($sync -or $install) {
             $appName = (Get-NAVAppInfo -Path $appFile).Name
             $appVersion = (Get-NAVAppInfo -Path $appFile).Version
     
             if ($sync) {
                 Write-Host "Synchronizing $appName on tenant $tenant"
-                Sync-NavTenant -ServerInstance NAV -Tenant $tenant -Force
+                Sync-NavTenant -ServerInstance NAV -Tenant $tenant -Mode $syncMode -Force
                 Sync-NavApp -ServerInstance NAV -Name $appName -Version $appVersion -Tenant $tenant -WarningAction Ignore
             }
     
@@ -84,7 +96,7 @@ function Publish-NavContainerApp {
         if ($copied) { 
             Remove-Item $appFile -Force
         }
-    } -ArgumentList $containerAppFile, $skipVerification, $copied, $sync, $install, $tenant, $packageType
+    } -ArgumentList $containerAppFile, $skipVerification, $copied, $sync, $install, $tenant, $packageType, $scope, $syncMode
     Write-Host -ForegroundColor Green "App successfully published"
 }
 Export-ModuleMember -Function Publish-NavContainerApp


### PR DESCRIPTION
New parameters in Publish-NavContainerApp:

- scope - to enable publish and install as tenant extension, which is similar to how AL extension in VS Code works.
- syncMode - to enable Add, Clean or Development mode for database schema synchronization. The default sync mode used by VS Code is Development, to enforce database synchronization without increasing the version number of the app.