### PR TITLE
fixed format for servers with different culture

### DIFF
--- a/AppHandling/Convert-CALTestOutputToAzureDevOps.ps1
+++ b/AppHandling/Convert-CALTestOutputToAzureDevOps.ps1
@@ -41,7 +41,7 @@ function Convert-CALTestOutputToAzureDevOps {
             $test.SetAttribute("name", $_.FName)
             $test.SetAttribute("method", $_.FName)
             $time = Convert-CALExecutionTimeToTimeSpan -CALExecutionTime $_.ExecutionTime
-            $test.SetAttribute("time", $time.TotalSeconds.ToString())
+            $test.SetAttribute("time", $time.TotalSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture))
             if ($_.Result -eq "Passed") {
                 $test.SetAttribute("result", "Pass")
                 $pass++
@@ -66,14 +66,14 @@ function Convert-CALTestOutputToAzureDevOps {
             $collection.AppendChild($test) | Out-Null
             $total += $time
         }
-        $collection.SetAttribute("time", $total.TotalSeconds.ToString())
+        $collection.SetAttribute("time", $total.TotalSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture))
         $collection.SetAttribute("total",($pass+$fail))
         $collection.SetAttribute("passed",$pass)
         $collection.SetAttribute("failed",$fail)
         $assembly.SetAttribute("total",($pass+$fail))
         $assembly.SetAttribute("passed",$pass)
         $assembly.SetAttribute("failed",$fail)
-        $assembly.SetAttribute("time", $total.TotalSeconds.ToString())
+        $assembly.SetAttribute("time", $total.TotalSeconds.ToString([System.Globalization.CultureInfo]::InvariantCulture))
         $assembly.AppendChild($collection) | Out-Null
     }
     $doc


### PR DESCRIPTION
On none English servers the function generates "Time"-Values like "260,336" which will be interpreted by DevOps as 3 days instead of 4 minutes.

The added parameter will ignore the local format and always export with "." (dot) as decimal marker.