### PR TITLE
DevOps error detection ALC internal error

### DIFF
--- a/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
+++ b/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
@@ -43,6 +43,12 @@ Function Convert-AlcOutputToAzureDevOps {
                     Write-Host "##vso[task.logissue type=error;sourcepath=$($Matches[1]);linenumber=$($Matches[2]);columnnumber=$($Matches[3]);code=$($Matches[4]);]$($Matches[5])"
                     $hasError = $true
                 }
+                "^(.*)error (\w{2}\d{4}): (.*)$"
+                #error AL0999: Internal error: System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException
+                {
+                    Write-Host "##vso[task.logissue type=error;code=$($Matches[2]);]$($Matches[3])"
+                    $hasError = $true
+                }
                 "^(.*)\((\d+),(\d+)\): warning (\w{2}\d{4}): (.*)$"
                 #Prepared for unified warning format
                 #Objects\codeunit\Cod50130.name.al(62,30): warning AL0118: The name '"Parent Object"' does not exist in the current context        


### PR DESCRIPTION
Added case to report error to DevOps for ALC internal errors like:
`error AL0999: Internal error: System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException...`