### PR TITLE
Invoke-ScriptInNAVContainer fix - use base64 for arguments

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -53,7 +53,11 @@ function Invoke-ScriptInNavContainer {
                 foreach($node in $nodes) {
                     $node.InnerText = ConvertFrom-SecureString -SecureString ($node.InnerText | ConvertTo-SecureString) -Key $encryptionkey
                 }
-                '$xml = [xml](''' + $xml.OuterXml + ''')' | Add-Content $file
+                
+                $xmlbytes =[System.Text.Encoding]::UTF8.GetBytes($xml.OuterXml)
+                '$xmlbytes = [Convert]::FromBase64String('''+[Convert]::ToBase64String($xmlbytes)+''')' | Add-Content $file
+                '$xml = [xml]([System.Text.Encoding]::UTF8.GetString($xmlbytes))' | Add-Content $file
+
                 if ($encryptionKey) {
                     '$nsmgr = New-Object System.Xml.XmlNamespaceManager -ArgumentList $xml.NameTable' | Add-Content $file
                     '$nsmgr.AddNamespace("ns", "http://schemas.microsoft.com/powershell/2004/04")' | Add-Content $file


### PR DESCRIPTION
There was a problem when using Invoke-ScriptInNavContainer in a non-admin session. If one of the params contained apostrophes (i.e. $param = "UPDATE xxx SET `"Field A`" = '' " ), the temporary script file that was created contained a xml string with unescaped apostrophes. When running the temporary script file the xml string wasn't completly interpreted, resulting in an missing apostrophe in the param. This is now fixed by converting the whole XML to base64, which is converted back before the xml string is loaded.

