### PR TITLE
Fix container variable name in Create-AlProjectFolderFromNavContainer

### DIFF
--- a/AppHandling/Create-AlProjectFolderFromNavContainer.ps1
+++ b/AppHandling/Create-AlProjectFolderFromNavContainer.ps1
@@ -47,7 +47,7 @@ function Create-AlProjectFolderFromNavContainer {
         [switch] $useBaseLine
     )
 
-    $navversion = Get-NavContainerNavversion -containerOrImageName $imageName
+    $navversion = Get-NavContainerNavversion -containerOrImageName $containerName
     $alFolder   = Join-Path $ExtensionsFolder "Original-$navversion-al"
     $dotnetAssembliesFolder = Join-Path $ExtensionsFolder "$containerName\.netPackages"
 


### PR DESCRIPTION
Container variable name in script was $imageName that did not exist. Fixed variable name to $containerName