### PR TITLE
Ignore WARNING lines when getting companies

### DIFF
--- a/CompanyHandling/Get-CompanyInNavContainer.ps1
+++ b/CompanyHandling/Get-CompanyInNavContainer.ps1
@@ -20,6 +20,6 @@ function Get-CompanyInNavContainer {
 
     Invoke-ScriptInNavContainer -containerName $containerName -ScriptBlock { Param($tenant)
         Get-NavCompany -ServerInstance NAV -Tenant $tenant
-    } -ArgumentList $tenant | Where-Object {$_ -notlike 'WARNING*'}
+    } -ArgumentList $tenant | Where-Object {$_ -isnot [System.String]}
 }
 Export-ModuleMember -Function Get-CompanyInNavContainer

--- a/CompanyHandling/Get-CompanyInNavContainer.ps1
+++ b/CompanyHandling/Get-CompanyInNavContainer.ps1
@@ -20,6 +20,6 @@ function Get-CompanyInNavContainer {
 
     Invoke-ScriptInNavContainer -containerName $containerName -ScriptBlock { Param($tenant)
         Get-NavCompany -ServerInstance NAV -Tenant $tenant
-    } -ArgumentList $tenant
+    } -ArgumentList $tenant | Where-Object {$_ -notlike 'WARNING*'}
 }
 Export-ModuleMember -Function Get-CompanyInNavContainer


### PR DESCRIPTION
The output of Get-CompanyInNavContainer includes any warning lines that are returned by PowerShell e.g. licence about to expire, licence not compatible.

Added a Where to remove those lines. I guess this may be a problem for other commands as well but I'm not sure how you'd filter them out without changing each place Invoke-ScriptInNavContainer is called from.