### PR TITLE
Add Traefik support

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -269,7 +269,7 @@ function New-NavContainer {
         $useSSL = $false
     }
 
-    if (Test-Path "C:\inetpub\wwwroot\hostname.txt") {
+    if (Test-Path "C:\inetpub\wwwroot\hostname.txt" -and -not $PublicDnsName) {
         $PublicDnsName = Get-Content -Path "C:\inetpub\wwwroot\hostname.txt" 
     }
     if (-not $PublicDnsName -and $useTraefik) {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -269,6 +269,9 @@ function New-NavContainer {
         $useSSL = $false
     }
 
+    if (Test-Path "C:\inetpub\wwwroot\hostname.txt") {
+        $PublicDnsName = Get-Content -Path "C:\inetpub\wwwroot\hostname.txt" 
+    }
     if (-not $PublicDnsName -and $useTraefik) {
         throw "Using Traefik only makes sense if you allow external access, so you have to provide the public DNS name (param -PublicDnsName)"
     }

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -256,6 +256,11 @@ function New-NavContainer {
     $dockerServerVersion = (docker version -f "{{.Server.Version}}")
     Write-Host "Docker Server Version is $dockerClientVersion"
 
+    $traefikForBcBasePath = "c:\programdata\navcontainerhelper\traefikforbc"
+    if ($useTraefik -and -not (Test-Path -Path (Join-Path $traefikForBcBasePath "traefik.txt") -PathType Leaf)) {
+        throw "Traefik container was not initialized. Please call Setup-TraefikContainerForNavContainers before using -useTraefik"
+    }
+
     if ($useTraefik -and (
         $PublishPorts.Count -gt 0 -or
         $WebClientPort -or $FileSharePort -or $ManagementServicesPort -or $ClientServicesPort -or 
@@ -586,7 +591,7 @@ function New-NavContainer {
 
     if ($useTraefik) {
         Write-Host "Add specific CheckHealth.ps1 to enable Traefik support"
-        $myscripts += "c:\traefikforbc\my\CheckHealth.ps1"
+        $myscripts += (Join-Path $traefikForBcBasePath "my\CheckHealth.ps1")
     }
 
     $myScripts | ForEach-Object {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -84,6 +84,8 @@
  .Parameter $PublicDnsName
   Use this parameter to specify which public dns name is pointing to this container.
   This parameter is necessary if you want to be able to connect to the container from outside the host.
+ .Parameter $useTraefik
+  Set the necessary options to make the container work behind a traefik proxy as explained here https://www.axians-infoma.com/techblog/running-multiple-nav-bc-containers-on-an-azure-vm/
  .Example
   New-NavContainer -accept_eula -containerName test
  .Example
@@ -147,7 +149,8 @@ function New-NavContainer {
         [int]$ODataServicesPort,
         [int]$DeveloperServicesPort,
         [int[]]$PublishPorts = @(),
-        [string]$PublicDnsName
+        [string]$PublicDnsName,
+        [switch]$useTraefik
     )
 
     if (!$accept_eula) {
@@ -252,6 +255,23 @@ function New-NavContainer {
 
     $dockerServerVersion = (docker version -f "{{.Server.Version}}")
     Write-Host "Docker Server Version is $dockerClientVersion"
+
+    if ($useTraefik -and (
+        $PublishPorts.Count -gt 0 -or
+        $WebClientPort -or $FileSharePort -or $ManagementServicesPort -or $ClientServicesPort -or 
+        $SoapServicesPort -or $ODataServicesPort -or $DeveloperServicesPort
+        )) {
+        throw "When using Traefik, all external communication comes in through port 443, so you can't change the ports"
+    }
+
+    if ($useSSL -and $useTraefik) {
+        Write-Host "Disabling SSL on the container as all external communictaion comes in through Traefik, which is handling the SSL cert"
+        $useSSL = $false
+    }
+
+    if (-not $PublicDnsName -and $useTraefik) {
+        throw "Using Traefik only makes sense if you allow external access, so you have to provide the public DNS name (param -PublicDnsName)"
+    }
 
     $parameters = @()
 
@@ -561,6 +581,11 @@ function New-NavContainer {
     $myFolder = Join-Path $containerFolder "my"
     New-Item -Path $myFolder -ItemType Directory -ErrorAction Ignore | Out-Null
 
+    if ($useTraefik) {
+        Write-Host "Add specific CheckHealth.ps1 to enable Traefik support"
+        $myscripts += "c:\traefikforbc\my\CheckHealth.ps1"
+    }
+
     $myScripts | ForEach-Object {
         if ($_ -is [string]) {
             if ($_.StartsWith("https://", "OrdinalIgnoreCase") -or $_.StartsWith("http://", "OrdinalIgnoreCase")) {
@@ -759,6 +784,46 @@ Get-NavServerUser -serverInstance NAV -tenant default |? LicenseType -eq "FullUs
         ('
 . (Join-Path $PSScriptRoot "updatehosts.ps1") -hostsFile "c:\driversetc\hosts" -hostname '+$containername+' -ipAddress $ip
 ') | Add-Content -Path "$myfolder\AdditionalOutput.ps1"
+    }
+
+    if ($useTraefik) {
+        $restPart = "/${containerName}rest" 
+        $soapPart = "/${containerName}soap"
+        $devPart = "/${containerName}dev"
+        $dlPart = "/${containerName}dl"
+        $webclientPart = "/$containerName/"
+        $baseUrl = "https://$publicDnsName"
+        $restUrl = $baseUrl + $restPart
+        $soapUrl = $baseUrl + $soapPart
+        $webclientUrl = $baseUrl + $webclientPart
+
+        $customNavSettings = "PublicODataBaseUrl=$restUrl,PublicSOAPBaseUrl=$soapUrl,PublicWebBaseUrl=$webclientUrl"
+        $webclientRule="PathPrefix:$webclientPart"
+        $soapRule="PathPrefix:${soapPart};ReplacePathRegex: ^${soapPart}(.*) /NAV/WS/`$1"
+        $restRule="PathPrefix:${restPart};ReplacePathRegex: ^${restPart}(.*) /NAV/OData/`$1"
+        $devRule="PathPrefix:${devPart};ReplacePathRegex: ^${devPart}(.*) /NAV/`$1"
+        $dlRule="PathPrefixStrip:${dlPart}"
+        $traefikHostname = $publicDnsName.Substring(0, $publicDnsName.IndexOf("."))
+
+        $additionalTraefikParameters = @("--hostname $traefikHostname",
+                    "-e webserverinstance=$containerName",
+                    "-e publicdnsname=$publicDnsName", 
+                    "-e customNavSettings=$customNavSettings",
+                    "-l `"traefik.web.frontend.rule=$webclientRule`"", 
+                    "-l `"traefik.web.port=80`"",
+                    "-l `"traefik.soap.frontend.rule=$soapRule`"", 
+                    "-l `"traefik.soap.port=7047`"",
+                    "-l `"traefik.rest.frontend.rule=$restRule`"", 
+                    "-l `"traefik.rest.port=7048`"",
+                    "-l `"traefik.dev.frontend.rule=$devRule`"", 
+                    "-l `"traefik.dev.port=7049`"",
+                    "-l `"traefik.dl.frontend.rule=$dlRule`"", 
+                    "-l `"traefik.dl.port=8080`"",
+                    "-l `"traefik.enable=true`"",
+                    "-l `"traefik.frontend.entryPoints=https`""
+        )
+
+        $additionalTraefikParameters | ForEach-Object { $additionalParameters += $_ }
     }
 
     if ([System.Version]$genericTag -ge [System.Version]"0.0.3.0") {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -274,7 +274,7 @@ function New-NavContainer {
         $useSSL = $false
     }
 
-    if (Test-Path "C:\inetpub\wwwroot\hostname.txt" -and -not $PublicDnsName) {
+    if ((Test-Path "C:\inetpub\wwwroot\hostname.txt") -and -not $PublicDnsName) {
         $PublicDnsName = Get-Content -Path "C:\inetpub\wwwroot\hostname.txt" 
     }
     if (-not $PublicDnsName -and $useTraefik) {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -799,6 +799,8 @@ Get-NavServerUser -serverInstance NAV -tenant default |? LicenseType -eq "FullUs
         $restUrl = $baseUrl + $restPart
         $soapUrl = $baseUrl + $soapPart
         $webclientUrl = $baseUrl + $webclientPart
+        $devUrl = $baseUrl + $devPart
+        $dlUrl = $baseUrl + $dlPart
 
         $customNavSettings = "PublicODataBaseUrl=$restUrl,PublicSOAPBaseUrl=$soapUrl,PublicWebBaseUrl=$webclientUrl"
         $webclientRule="PathPrefix:$webclientPart"
@@ -1032,5 +1034,14 @@ Get-NavServerUser -serverInstance NAV -tenant default |? LicenseType -eq "FullUs
     }
 
     Write-Host -ForegroundColor Green "Nav container $containerName successfully created"
+
+    if ($useTraefik) {
+        Write-Host -ForegroundColor Yellow "Because of Traefik, the following URLs need to be used when accessing the container from outside your Docker host:"
+        Write-Host "Web Client:        $webclientUrl"
+        Write-Host "SOAP WebServices:  $soapUrl"
+        Write-Host "OData WebServices: $restUrl"
+        Write-Host "Dev Service:       $devUrl"
+        Write-Host "File downloads:    $dlUrl"
+    }
 }
 Export-ModuleMember -function New-NavContainer

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -1,0 +1,52 @@
+﻿<# 
+ .Synopsis
+  Set up a traefik container to manage traffic for Business Central containers
+ .Description
+  Set up a traefik container to manage traffic for Business Central containers
+ .Parameter overrideDefaultBinding
+  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+ .Example
+  Setup-TraefikContainerForNavContainers -overrideDefaultBinding
+#>
+function Setup-TraefikContainerForNavContainers {
+    [CmdletBinding()]
+    Param
+    (
+        [switch]$overrideDefaultBinding
+    )
+
+    Process {
+        $traefikForBcBasePath = "c:\programdata\navcontainerhelper\traefikforbc"
+
+        if (Test-Path -Path (Join-Path $traefikForBcBasePath "traefik.txt") -PathType Leaf) {
+            Write-Host "Traefik container already initialized."
+            exit
+        }
+
+        Write-Host "Creating folder structure at $traefikForBcBasePath"
+        New-Item $traefikForBcBasePath -ItemType Directory
+        New-Item (Join-Path $traefikForBcBasePath "traefik.txt") -ItemType File
+        New-Item (Join-Path $traefikForBcBasePath "my") -ItemType Directory
+        New-Item (Join-Path $traefikForBcBasePath "config") -ItemType Directory
+        New-Item (Join-Path $traefikForBcBasePath "config\acme.json") -ItemType File
+
+        Copy-Item (Join-Path $PSScriptRoot "traefik\template_traefik.toml") -Destination (Join-Path $traefikForBcBasePath "config\template_traefik.toml")
+        Copy-Item (Join-Path $PSScriptRoot "traefik\CheckHealth.ps1") -Destination (Join-Path $traefikForBcBasePath "my\CheckHealth.ps1")
+
+        Write-Host "Create traefik config file"
+        $template = Get-Content (Join-Path $traefikForBcBasePath "config\template_traefik.toml") -Raw
+        $expanded = Invoke-Expression "@`"`r`n$template`r`n`"@"
+        $expanded | Out-File (Join-Path $traefikForBcBasePath "config\traefik.toml") -Encoding ASCII
+
+        if ($overrideDefaultBinding) {
+            Write-Host "Change standard port as Traefik will handle that. Content previously avaiable on port 80 will be available on 8180"
+            Set-WebBinding -Name 'Default Web Site' -BindingInformation "*:80:" -PropertyName Port -Value 8180
+            New-NetFirewallRule -DisplayName "Allow 8180" -Direction Inbound -Action Allow -Protocol TCP -LocalPort 8180
+        }
+
+        Log "Pulling and running traefik"
+        docker pull stefanscherer/traefik-windows
+        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v (Join-Path $traefikForBcBasePath "config"):c:/etc/traefik -v \\.\pipe\docker_engine:\\.\pipe\docker_engine stefanscherer/traefik-windows --docker.endpoint=npipe:////./pipe/docker_engine
+    }
+}
+Export-ModuleMember -function Setup-TraefikContainerForNavContainers

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -3,6 +3,10 @@
   Set up a traefik container to manage traffic for Business Central containers
  .Description
   Set up a traefik container to manage traffic for Business Central containers
+ .Parameter PublicDnsName
+  The externally reachable FQDN of your Docker host
+ .Parameter ContactEMailForLetsEncrypt
+  The eMail address to use when requesting an SSL cert from Let's encrypt
  .Parameter overrideDefaultBinding
   Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
  .Example
@@ -12,6 +16,10 @@ function Setup-TraefikContainerForNavContainers {
     [CmdletBinding()]
     Param
     (
+        [Parameter(Mandatory=$true)]
+        [string]$PublicDnsName,
+        [Parameter(Mandatory=$true)]
+        [string]$ContactEMailForLetsEncrypt,
         [switch]$overrideDefaultBinding
     )
 
@@ -46,7 +54,7 @@ function Setup-TraefikContainerForNavContainers {
 
         Log "Pulling and running traefik"
         docker pull stefanscherer/traefik-windows
-        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v (Join-Path $traefikForBcBasePath "config"):c:/etc/traefik -v \\.\pipe\docker_engine:\\.\pipe\docker_engine stefanscherer/traefik-windows --docker.endpoint=npipe:////./pipe/docker_engine
+        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine stefanscherer/traefik-windows --docker.endpoint=npipe:////./pipe/docker_engine
     }
 }
 Export-ModuleMember -function Setup-TraefikContainerForNavContainers

--- a/ContainerHandling/traefik/CheckHealth.ps1
+++ b/ContainerHandling/traefik/CheckHealth.ps1
@@ -1,0 +1,10 @@
+$healthcheckurl = ("http://localhost/" + $env:webserverinstance + "/")
+try {
+    $result = Invoke-WebRequest -Uri "${healthcheckurl}Health/System" -UseBasicParsing -TimeoutSec 10
+    if ($result.StatusCode -eq 200 -and ((ConvertFrom-Json $result.Content).result)) {
+        # Web Client Health Check Endpoint will test Web Client, Service Tier and Database Connection
+        exit 0
+    }
+} catch {
+}
+exit 1

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -1,0 +1,28 @@
+debug = false
+defaultEntryPoints = ["https","http"]
+
+[web]
+address = ":8080"
+
+[docker]
+domain = "$PublicDnsName"
+watch = true
+endpoint = "npipe:////./pipe/docker_engine"
+
+[entryPoints]
+  [entryPoints.http]
+  address = ":80"
+    [entryPoints.http.redirect]
+    entryPoint = "https"
+  [entryPoints.https]
+  address = ":443"
+  [entryPoints.https.tls]
+
+[acme]
+email = "$ContactEMailForLetsEncrypt"
+storage = "c:/etc/traefik/acme.json"
+entryPoint = "https"
+[acme.httpChallenge]
+entryPoint = "http"
+[[acme.domains]]
+   main = "$PublicDnsName"

--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -85,6 +85,7 @@ Check-NavContainerHelperPermissions -Silent
 . (Join-Path $PSScriptRoot "ContainerHandling\Extract-FilesFromStoppedNavContainer.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\Get-BestNavContainerImageName.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\Invoke-ScriptInNavContainer.ps1")
+. (Join-Path $PSScriptRoot "ContainerHandling\Setup-TraefikContainerForNavContainers.ps1")
 
 # Object Handling functions
 . (Join-Path $PSScriptRoot "ObjectHandling\Export-NavContainerObjects.ps1")


### PR DESCRIPTION
This allows creating a new NAV container with the necessary settings and labels for Traefik as explained here https://www.axians-infoma.com/techblog/running-multiple-nav-bc-containers-on-an-azure-vm/

With the PR in place you can create a new container reachable through Traefik as easy as this:

```
New-NavContainer -accept_eula -containerName imau -imageName mcr.microsoft.com/businesscentral/onprem:de -useTraefik
NavContainerHelper is version 0.0
Host is Microsoft Windows Server 2019 Datacenter - ltsc2019
Docker Client Version is 18.09.4
Docker Server Version is 18.09.4
Using image mcr.microsoft.com/businesscentral/onprem:de-ltsc2019
PublicDnsName is traef-test10.westeurope.cloudapp.azure.com
Creating Nav container imau
Version: 14.0.29537.0-de
Platform: 14.0.29530.0
Generic Tag: 0.0.9.5
Container OS Version: 10.0.17763.437 (ltsc2019)
Host OS Version: 10.0.17763.437 (ltsc2019)
Using process isolation
Add specific CheckHealth.ps1 to enable Traefik support
Creating container imau from image mcr.microsoft.com/businesscentral/onprem:de-ltsc2019
5fd76cff1c74cfb316742dd33bfbf0a4707bc7bb58b8a90d18bc974206e79a64
Waiting for container imau to be ready
Initializing...
Starting Container
Hostname is traef-test10
PublicDnsName is traef-test10.westeurope.cloudapp.azure.com
Using Windows Authentication
Starting Local SQL Server
Starting Internet Information Server
Modifying Service Tier Config File with Instance Specific Settings
Modifying Service Tier Config File with settings from environment variable
Setting PublicODataBaseUrl to https://traef-test10.westeurope.cloudapp.azure.com/imaurest
Setting PublicSOAPBaseUrl to https://traef-test10.westeurope.cloudapp.azure.com/imausoap
Setting PublicWebBaseUrl to https://traef-test10.westeurope.cloudapp.azure.com/imau/
Starting Service Tier
Creating DotNetCore Web Server Instance
Creating http download site
Creating Windows user vmadmin
Setting SA Password and enabling SA
Creating SUPER user
Registering event sources
Container IP Address: 172.23.78.199
Container Hostname  : traef-test10
Container Dns Name  : traef-test10.westeurope.cloudapp.azure.com
Web Client          : http://traef-test10.westeurope.cloudapp.azure.com/imau/
Dev. Server         : http://traef-test10.westeurope.cloudapp.azure.com
Dev. ServerInstance : NAV

Files:
http://traef-test10.westeurope.cloudapp.azure.com:8080/al-3.0.106655.vsix

Initialization took 82 seconds
Ready for connections!
Reading CustomSettings.config from imau
Creating Desktop Shortcuts for imau
Nav container imau successfully created
Because of Traefik, the following URLs need to be used when accessing the container from outside your Docker host:
Web Client:        https://traef-test10.westeurope.cloudapp.azure.com/imau/
SOAP WebServices:  https://traef-test10.westeurope.cloudapp.azure.com/imausoap
OData WebServices: https://traef-test10.westeurope.cloudapp.azure.com/imaurest
Dev Service:       https://traef-test10.westeurope.cloudapp.azure.com/imaudev
File downloads:    https://traef-test10.westeurope.cloudapp.azure.com/imaudl
```