### PR TITLE
Add EventMessageFile for default NAV Server Instance

### DIFF
--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -32,6 +32,14 @@ if (!(Test-Path -Path $extensionsFolder -PathType Container)) {
     }
 }
 
+if ($isAdministrator) {
+    $RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\MicrosoftDynamicsNavServer$NAV'
+    if (-not(Test-Path -Path $RegPath)){
+        New-Item -Path $RegPath -Force | Out-Null
+        New-ItemProperty -Path $RegPath -Name 'EventMessageFile' -Value "$env:windir\Microsoft.NET\Framework64\v4.0.30319\EventLogMessages.dll" -PropertyType ExpandString -Force
+    }
+}
+
 $containerHelperFolder = "C:\ProgramData\NavContainerHelper"
 
 $sessions = @{}

--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -36,7 +36,7 @@ if ($isAdministrator) {
     $RegPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\MicrosoftDynamicsNavServer$NAV'
     if (-not(Test-Path -Path $RegPath)){
         New-Item -Path $RegPath -Force | Out-Null
-        New-ItemProperty -Path $RegPath -Name 'EventMessageFile' -Value "$env:windir\Microsoft.NET\Framework64\v4.0.30319\EventLogMessages.dll" -PropertyType ExpandString -Force
+        New-ItemProperty -Path $RegPath -Name 'EventMessageFile' -Value "$env:windir\Microsoft.NET\Framework64\v4.0.30319\EventLogMessages.dll" -PropertyType ExpandString -Force | Out-Null
     }
 }
 


### PR DESCRIPTION
Get rid of this message in the eventlog after running Get-NavContainerEventLog:

> The description for Event ID ### from source MicrosoftDynamicsNavServer$NAV cannot be found. Either the component that raises this event is not installed on your local computer or the installation is corrupted. You can install or repair the component on the local computer.
> 
> If the event originated on another computer, the display information had to be saved with the event.
> 
> The following information was included with the event: 
> [...]