### PR TITLE
Improve Traefik usage: fixed version + improved security for the UI

### DIFF
--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -25,6 +25,7 @@ function Setup-TraefikContainerForNavContainers {
 
     Process {
         $traefikForBcBasePath = "c:\programdata\navcontainerhelper\traefikforbc"
+        $traefikDockerImage = "stefanscherer/traefik-windows:v1.7.12"
 
         if (Test-Path -Path (Join-Path $traefikForBcBasePath "traefik.txt") -PathType Leaf) {
             Write-Host "Traefik container already initialized."
@@ -53,8 +54,8 @@ function Setup-TraefikContainerForNavContainers {
         }
 
         Log "Pulling and running traefik"
-        docker pull stefanscherer/traefik-windows
-        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine stefanscherer/traefik-windows --docker.endpoint=npipe:////./pipe/docker_engine
+        docker pull $traefikDockerImage
+        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $traefikDockerImage --docker.endpoint=npipe:////./pipe/docker_engine
     }
 }
 Set-Alias -Name Setup-TraefikContainerForBCContainers -Value Setup-TraefikContainerForNavContainers

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -55,7 +55,7 @@ function Setup-TraefikContainerForNavContainers {
 
         Log "Pulling and running traefik"
         docker pull $traefikDockerImage
-        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $traefikDockerImage --docker.endpoint=npipe:////./pipe/docker_engine
+        docker run -p 8080:127.0.0.1:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $traefikDockerImage --docker.endpoint=npipe:////./pipe/docker_engine
     }
 }
 Set-Alias -Name Setup-TraefikContainerForBCContainers -Value Setup-TraefikContainerForNavContainers

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -1,8 +1,7 @@
 debug = false
 defaultEntryPoints = ["https","http"]
 
-[web]
-address = ":8080"
+[api]
 
 [docker]
 domain = "$PublicDnsName"

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -2,6 +2,8 @@ debug = false
 defaultEntryPoints = ["https","http"]
 
 [api]
+# Check https://docs.traefik.io/v1.7/configuration/api/#security
+# to enable authentication on the dashboard for extra security
 
 [docker]
 domain = "$PublicDnsName"


### PR DESCRIPTION
Hi dear maintainers, thanks for this cool piece of software!

After discovering this projects thanks to the blog posts of @tfenster (https://www.axians-infoma.de/techblog/traefik-support-for-navcontainerhelper-the-nav-arm-templates-for-azure-vms-and-local-environments/), I wanted to propose some practises we recommend to Traefik users.

This PR introduces the following changes:

- Fix the version of Traefik. As the version 2.0 is [in alpha version and would have breaking changes](https://blog.containo.us/back-to-traefik-2-0-2f9aa17be305), better fixing the version by using docker tag, as Stefan is doing an awesome work by maintaining a Windows Docker image with a lot of tags.
  - Cost of this change is that this version should be updated to follow Traefik.

- Fix a deprecated configuration in the Traefik configuration (file `template_traefik.toml`), as the block `[web]`and its content is deprecated  (reference: https://docs.traefik.io/v1.7/configuration/backends/web/ ). The block `[api]` is replacing it, and defaults to the port 8080.

- Improve security of the users, by restricting the port 8080 of Traefik's container only to the loopback of the Docker host (reference https://docs.traefik.io/v1.7/configuration/api/#security):
  - End user can still access the dashboard if they can access the Docker host (on http://localhost:8080), but the dashboard (and so the full Traefik routing configuration through the API) is not publicly exposed
  - Adding a note for extra security in the `template_traefik.toml`


Further reference: same kind of change had been merged in Stefan's windows image: https://github.com/StefanScherer/dockerfiles-windows/pull/417.

What do you think of this change?