### PR TITLE
switch landing page to /landing instead of :8180

### DIFF
--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -56,7 +56,7 @@ function Setup-TraefikContainerForNavContainers {
 
         Log "Pulling and running traefik"
         docker pull $traefikDockerImage
-        docker run -p 8080:127.0.0.1:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $traefikDockerImage --docker.endpoint=npipe:////./pipe/docker_engine
+        docker run -p 8080:8080 -p 443:443 -p 80:80 --restart always -d -v ((Join-Path $traefikForBcBasePath "config") + ":c:/etc/traefik") -v \\.\pipe\docker_engine:\\.\pipe\docker_engine $traefikDockerImage --docker.endpoint=npipe:////./pipe/docker_engine
     }
 }
 Set-Alias -Name Setup-TraefikContainerForBCContainers -Value Setup-TraefikContainerForNavContainers

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -44,6 +44,7 @@ function Setup-TraefikContainerForNavContainers {
 
         Write-Host "Create traefik config file"
         $template = Get-Content (Join-Path $traefikForBcBasePath "config\template_traefik.toml") -Raw
+        $IP = (Get-NetIPAddress -AddressFamily IPv4)[0].IPAddress
         $expanded = Invoke-Expression "@`"`r`n$template`r`n`"@"
         $expanded | Out-File (Join-Path $traefikForBcBasePath "config\traefik.toml") -Encoding ASCII
 

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -44,7 +44,7 @@ function Setup-TraefikContainerForNavContainers {
 
         Write-Host "Create traefik config file"
         $template = Get-Content (Join-Path $traefikForBcBasePath "config\template_traefik.toml") -Raw
-        $IP = (Get-NetIPAddress -AddressFamily IPv4)[0].IPAddress
+        $IP = (Get-NetIPAddress -AddressFamily IPv4 | Where-Object PrefixOrigin -eq "Dhcp").IPAddress
         $expanded = Invoke-Expression "@`"`r`n$template`r`n`"@"
         $expanded | Out-File (Join-Path $traefikForBcBasePath "config\traefik.toml") -Encoding ASCII
 

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -38,4 +38,4 @@ entryPoint = "http"
   [frontends.host]
     backend = "host"
     [frontends.host.routes.route1]
-      rule = "PathPrefixStrip:/landing"
+      rule = "PathPrefix:/"

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -27,3 +27,15 @@ entryPoint = "https"
 entryPoint = "http"
 [[acme.domains]]
    main = "$PublicDnsName"
+
+[file]
+[backends]
+  [backends.host]
+    [backends.host.servers.server1]
+       url = "http://$IP:8180"
+
+[frontends]
+  [frontends.host]
+    backend = "host"
+    [frontends.host.routes.route1]
+      rule = "PathPrefixStrip:/landing"

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -32,7 +32,7 @@ entryPoint = "http"
 [backends]
   [backends.host]
     [backends.host.servers.server1]
-       url = "http://$IP:8180"
+       url = "http://${IP}:8180"
 
 [frontends]
   [frontends.host]


### PR DESCRIPTION
Instead of using the unusual port of 8180 which lessens discoverability and increases complexity, use /landing on standard port 443. Works in connection with https://github.com/microsoft/nav-arm-templates/pull/109