### PR TITLE
Improve Traefik: Use custom toml and certificate for own domain

### DIFF
--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -1,4 +1,4 @@
-﻿<# 
+﻿<#
  .Synopsis
   Set up a traefik container to manage traffic for Business Central containers
  .Description
@@ -9,6 +9,12 @@
   The eMail address to use when requesting an SSL cert from Let's encrypt
  .Parameter overrideDefaultBinding
   Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+ .Parameter traefikToml
+  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+ .Parameter CrtFile
+  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+ .Parameter CertKeyFile
+  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
  .Example
   Setup-TraefikContainerForNavContainers -overrideDefaultBinding
 #>
@@ -18,18 +24,42 @@ function Setup-TraefikContainerForNavContainers {
     (
         [Parameter(Mandatory=$true)]
         [string]$PublicDnsName,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$true, ParameterSetName="LetsEncrypt")]
         [string]$ContactEMailForLetsEncrypt,
-        [switch]$overrideDefaultBinding
+        [switch]$overrideDefaultBinding,
+        [Parameter(Mandatory=$true)]
+        [string]$traefikToml = (Join-Path $PSScriptRoot "traefik\template_traefik.toml"),
+        [Parameter(Mandatory=$true, ParameterSetName="OwnCertificate")]
+        [string]$CrtFile,
+        [Parameter(Mandatory=$true, ParameterSetName="OwnCertificate")]
+        [string]$CrtKeyFile
     )
 
     Process {
         $traefikForBcBasePath = "c:\programdata\navcontainerhelper\traefikforbc"
         $traefikDockerImage = "stefanscherer/traefik-windows:v1.7.12"
+        $traefiktomltemplate = (Join-Path $traefikForBcBasePath "config\template_traefik.toml")
+        $CrtFilePath = (Join-Path $traefikForBcBasePath "config\certificate.crt")
+        $CrtKeyFilePath = (Join-Path $traefikForBcBasePath "config\certificate.key")
 
         if (Test-Path -Path (Join-Path $traefikForBcBasePath "traefik.txt") -PathType Leaf) {
             Write-Host "Traefik container already initialized."
             exit
+        }
+
+        if ($traefikToml -is [string]) {
+            if ($traefikToml.ToLower().StartsWith("http://") -or $traefikToml.ToLower().StartsWith("https://")) {
+                $traefikTomlFile = (Join-Path $PSScriptRoot "traefik\template_traefik_custom.toml")
+                (New-Object System.Net.WebClient).DownloadFile($traefikToml, $traefikTomlFile)
+            } else {
+                if (!(Test-Path $traefikToml)) {
+                    throw "File $traefikToml does not exist"
+                } else {
+                    $traefikTomlFile = $traefikToml
+                }
+            }
+        } else {
+            throw "Illegal value in traefikToml"
         }
 
         Write-Host "Creating folder structure at $traefikForBcBasePath"
@@ -39,14 +69,42 @@ function Setup-TraefikContainerForNavContainers {
         New-Item (Join-Path $traefikForBcBasePath "config") -ItemType Directory
         New-Item (Join-Path $traefikForBcBasePath "config\acme.json") -ItemType File
 
-        Copy-Item (Join-Path $PSScriptRoot "traefik\template_traefik.toml") -Destination (Join-Path $traefikForBcBasePath "config\template_traefik.toml")
+        Copy-Item $traefikTomlFile -Destination $traefiktomltemplate
         Copy-Item (Join-Path $PSScriptRoot "traefik\CheckHealth.ps1") -Destination (Join-Path $traefikForBcBasePath "my\CheckHealth.ps1")
 
+        if ($CrtFile -is [string]) {
+            if ($CrtFile.ToLower().StartsWith("http://") -or $CrtFile.ToLower().StartsWith("https://")) {
+                (New-Object System.Net.WebClient).DownloadFile($CrtFile, $CrtFilePath)
+            } else {
+                if (!(Test-Path $CrtFile)) {
+                    throw "File $CrtFile does not exist"
+                } else {
+                    Copy-Item $CrtFile -Destination $CrtFilePath
+                }
+            }
+        } else {
+            throw "Illegal value in CrtFile"
+        }
+
+        if ($CrtKeyFile -is [string]) {
+            if ($CrtKeyFile.ToLower().StartsWith("http://") -or $CrtKeyFile.ToLower().StartsWith("https://")) {
+                (New-Object System.Net.WebClient).DownloadFile($CrtKeyFile, $CrtKeyFilePath)
+            } else {
+                if (!(Test-Path $CrtKeyFile)) {
+                    throw "File $CrtKeyFile does not exist"
+                } else {
+                    Copy-Item $CrtKeyFile -Destination $CrtKeyFilePath
+                }
+            }
+        } else {
+            throw "Illegal value in CertKeyFile"
+        }
+
         Write-Host "Create traefik config file"
-        $template = Get-Content (Join-Path $traefikForBcBasePath "config\template_traefik.toml") -Raw
+        $template = Get-Content $traefiktomltemplate -Raw
         $expanded = Invoke-Expression "@`"`r`n$template`r`n`"@"
         $expanded | Out-File (Join-Path $traefikForBcBasePath "config\traefik.toml") -Encoding ASCII
-
+        break
         if ($overrideDefaultBinding) {
             Write-Host "Change standard port as Traefik will handle that. Content previously avaiable on port 80 will be available on 8180"
             Set-WebBinding -Name 'Default Web Site' -BindingInformation "*:80:" -PropertyName Port -Value 8180

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -72,39 +72,43 @@ function Setup-TraefikContainerForNavContainers {
         Copy-Item $traefikTomlFile -Destination $traefiktomltemplate
         Copy-Item (Join-Path $PSScriptRoot "traefik\CheckHealth.ps1") -Destination (Join-Path $traefikForBcBasePath "my\CheckHealth.ps1")
 
-        if ($CrtFile -is [string]) {
-            if ($CrtFile.ToLower().StartsWith("http://") -or $CrtFile.ToLower().StartsWith("https://")) {
-                (New-Object System.Net.WebClient).DownloadFile($CrtFile, $CrtFilePath)
-            } else {
-                if (!(Test-Path $CrtFile)) {
-                    throw "File $CrtFile does not exist"
+        if($CrtFile) {
+            if ($CrtFile -is [string]) {
+                if ($CrtFile.ToLower().StartsWith("http://") -or $CrtFile.ToLower().StartsWith("https://")) {
+                    (New-Object System.Net.WebClient).DownloadFile($CrtFile, $CrtFilePath)
                 } else {
-                    Copy-Item $CrtFile -Destination $CrtFilePath
+                    if (!(Test-Path $CrtFile)) {
+                        throw "File $CrtFile does not exist"
+                    } else {
+                        Copy-Item $CrtFile -Destination $CrtFilePath
+                    }
                 }
+            } else {
+                throw "Illegal value in CrtFile"
             }
-        } else {
-            throw "Illegal value in CrtFile"
         }
 
-        if ($CrtKeyFile -is [string]) {
-            if ($CrtKeyFile.ToLower().StartsWith("http://") -or $CrtKeyFile.ToLower().StartsWith("https://")) {
-                (New-Object System.Net.WebClient).DownloadFile($CrtKeyFile, $CrtKeyFilePath)
-            } else {
-                if (!(Test-Path $CrtKeyFile)) {
-                    throw "File $CrtKeyFile does not exist"
+        if($CrtKeyFile) {
+            if ($CrtKeyFile -is [string]) {
+                if ($CrtKeyFile.ToLower().StartsWith("http://") -or $CrtKeyFile.ToLower().StartsWith("https://")) {
+                    (New-Object System.Net.WebClient).DownloadFile($CrtKeyFile, $CrtKeyFilePath)
                 } else {
-                    Copy-Item $CrtKeyFile -Destination $CrtKeyFilePath
+                    if (!(Test-Path $CrtKeyFile)) {
+                        throw "File $CrtKeyFile does not exist"
+                    } else {
+                        Copy-Item $CrtKeyFile -Destination $CrtKeyFilePath
+                    }
                 }
+            } else {
+                throw "Illegal value in CertKeyFile"
             }
-        } else {
-            throw "Illegal value in CertKeyFile"
         }
 
         Write-Host "Create traefik config file"
         $template = Get-Content $traefiktomltemplate -Raw
         $expanded = Invoke-Expression "@`"`r`n$template`r`n`"@"
         $expanded | Out-File (Join-Path $traefikForBcBasePath "config\traefik.toml") -Encoding ASCII
-        break
+
         if ($overrideDefaultBinding) {
             Write-Host "Change standard port as Traefik will handle that. Content previously avaiable on port 80 will be available on 8180"
             Set-WebBinding -Name 'Default Web Site' -BindingInformation "*:80:" -PropertyName Port -Value 8180

--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -10,11 +10,11 @@
  .Parameter overrideDefaultBinding
   Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
  .Parameter traefikToml
-  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+  Path/Url of the toml file for traefik
  .Parameter CrtFile
-  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+  Path/Url of the certificate crt file for using your own domain
  .Parameter CertKeyFile
-  Include this switch if you already have an IIS listening on port 80 on your Docker host. This will move the binding on port 80 to port 8180
+  Path/Url of the certificate key file for using your own domain
  .Example
   Setup-TraefikContainerForNavContainers -overrideDefaultBinding
 #>


### PR DESCRIPTION
This allows to use a custom instead of the default one. 
Also you can use your certificate for your own domain.

For using your certificate the toml has to look like this:

debug = false
defaultEntryPoints = ["https","http"]

[entryPoints]
  [entryPoints.http]
  address = ":80"
    [entryPoints.http.redirect]
    entryPoint = "https"
  [entryPoints.traefik]
  address = ":8080"
  [entryPoints.https]
  address = ":443"
  [entryPoints.https.tls]
    [[entryPoints.https.tls.certificates]]
    certFile = "c:/etc/traefik/certificate.crt"
    keyFile = "c:/etc/traefik/certificate.key"

[docker]
domain = "$PublicDnsName"
watch = true
endpoint = "npipe:////./pipe/docker_engine"

[api]
entryPoint = "traefik"`