### PR TITLE
AccessToken and Invoke-script

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -25,7 +25,14 @@ function Invoke-ScriptInNavContainer {
     )
 
     if ($usePsSession) {
-        $session = Get-NavContainerSession -containerName $containerName -silent
+        try {
+            $session = Get-NavContainerSession -containerName $containerName -silent
+        }
+        catch {
+            $usePsSession = $false
+        }
+    }
+    if ($usePsSession) {
         try {
             Invoke-Command -Session $session -ScriptBlock $scriptblock -ArgumentList $argumentList
         }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 0.6.2.8
 Get-TestsFromNavContainer and Run-TestsInNavContainer now supports NAV 2016, NAV 2017, NAV 2018 and Business Central.
 Issue #528 - add SqlCredential to Generate-SymbolsInNavContainer
+Support AccessToken as Office365Password instead of the AAD User Password (to allow MFA accounts)
 
 0.6.2.7
 Add -includeCSIDE parameter to Replace-NavServerContainer

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Get-TestsFromNavContainer and Run-TestsInNavContainer now supports NAV 2016, NAV 2017, NAV 2018 and Business Central.
 Issue #528 - add SqlCredential to Generate-SymbolsInNavContainer
 Support AccessToken as Office365Password instead of the AAD User Password (to allow MFA accounts)
+Invoke-ScriptInNavContainer automatically switches to docker exec if new-pssession fails
 
 0.6.2.7
 Add -includeCSIDE parameter to Replace-NavServerContainer


### PR DESCRIPTION
Support AccessToken as Office365Password instead of the AAD User Password (to allow MFA accounts)
Invoke-ScriptInNavContainer automatically switches to docker exec if new-pssession fails
