### PR TITLE
Write InnerExceptions if available

### DIFF
--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -67,6 +67,9 @@ class ClientContext {
         })
         $this.events += @(Register-ObjectEvent -InputObject $this.clientSession -EventName CommunicationError -Action {
             Write-Host -ForegroundColor Red "CommunicationError : $($EventArgs.Exception.Message)"
+            if ($null -ne $EventArgs.Exception.InnerException) {
+                Write-Host -ForegroundColor Red "CommunicationError InnerException : $($EventArgs.Exception.InnerException)"    
+            }
             if ($this.debugMode) {
                 $this.GetAllForms() | ForEach-Object {
                     $formInfo = $this.GetFormInfo($_)
@@ -81,6 +84,9 @@ class ClientContext {
         })
         $this.events += @(Register-ObjectEvent -InputObject $this.clientSession -EventName UnhandledException -Action {
             Write-Host -ForegroundColor Red "UnhandledException : $($EventArgs.Exception.Message)"
+            if ($null -ne $EventArgs.Exception.InnerException) {
+                Write-Host -ForegroundColor Red "UnhandledException InnerException : $($EventArgs.Exception.InnerException)"    
+            }
             if ($this.debugMode) {
                 $this.GetAllForms() | ForEach-Object {
                     $formInfo = $this.GetFormInfo($_)


### PR DESCRIPTION
I added a few lines to help troubleshoot the kind of strange errors as in #617 

If there are an InnerException available, it will be printed. 

Maybe it would be nicer to do it by recursion and only write the exception messages, but now I at least see all inner exceptions.

The text when getting theese error would then be something like below, with several levels of InnerExceptions:
```
CommunicationError : An error occurred while sending the request.
CommunicationError InnerException : System.Net.Http.HttpRequestException: An error occurred while sending the request. ---> System.Net.WebException: Unable to connect to the remote server ---> System.Net.Sockets.SocketException: No connection could be made because the target machine actively refused it 127.0.0.1:80
   at System.Net.Sockets.Socket.InternalEndConnect(IAsyncResult asyncResult)
   at System.Net.Sockets.Socket.EndConnect(IAsyncResult asyncResult)
   at System.Net.ServicePoint.ConnectSocketInternal(Boolean connectFailure, Socket s4, Socket s6, Socket& socket, IPAddress& address, ConnectSocketState state, IAsyncResult asyncResult, Exception& exception)
   --- End of inner exception stack trace ---
   at System.Net.HttpWebRequest.EndGetRequestStream(IAsyncResult asyncResult, TransportContext& context)
   at System.Net.Http.HttpClientHandler.GetRequestStreamCallback(IAsyncResult ar)
   --- End of inner exception stack trace ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.Dynamics.Framework.UI.Client.JsonHttpClient.<>c__DisplayClass9_0.<EndOpenSession>b__0() in s:\repo\src\Platform\Client\ClientService\Prod.Client.ClientService.Client\Service\ServiceClients\JsonHttpClient\JsonHttpClient.cs:line 158
   at Microsoft.Dynamics.Framework.UI.Client.JsonHttpClient.ConvertExceptions[T](Func`1 action) in s:\repo\src\Platform\Client\ClientService\Prod.Client.ClientService.Client\Service\ServiceClients\JsonHttpClient\JsonHttpClient.cs:line 181
ClientSession is Uninitialized
at AwaitState, C:\ProgramData\NavContainerHelper\Extensions\CI-bld12\PsTestTool-3\ClientContext.ps1: line 160
at OpenSession, C:\ProgramData\NavContainerHelper\Extensions\CI-bld12\PsTestTool-3\ClientContext.ps1: line 132
at Initialize, C:\ProgramData\NavContainerHelper\Extensions\CI-bld12\PsTestTool-3\ClientContext.ps1: line 46
at ClientContext, C:\ProgramData\NavContainerHelper\Extensions\CI-bld12\PsTestTool-3\ClientContext.ps1: line 23
at New-ClientContext, C:\ProgramData\NavContainerHelper\Extensions\CI-bld12\PsTestTool-3\PsTestFunctions.ps1: line 39
at <ScriptBlock>, <No file>: line 39
ClientSession is Uninitialized
At C:\Program Files\WindowsPowerShell\Modules\navcontainerhelper\0.6.4.1\ContainerHandling\Invoke-ScriptInNavContainer.ps1:37 char:13
+             Invoke-Command -Session $session -ScriptBlock $scriptbloc ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (ClientSession is Uninitialized:String) [], RuntimeException
    + FullyQualifiedErrorId : ClientSession is Uninitialized
```