### PR TITLE
Fix encoding for local special chars (mutated vowel, umlauts)

### DIFF
--- a/Api/Invoke-NavContainerApi.ps1
+++ b/Api/Invoke-NavContainerApi.ps1
@@ -145,7 +145,7 @@ function Invoke-NavContainerApi {
     }
     
     if ($body) {
-        $parameters += @{ "body" = $body | ConvertTo-Json }
+        $parameters += @{ "body" = [System.Text.UTF8Encoding]::GetEncoding('UTF-8').GetBytes((ConvertTo-Json $body)) }
     }
 
     if (!$silent) {


### PR DESCRIPTION
This change allows to do request with special characters like ä, ö, ü in the body.

Without this change the following command will fail:
```
$packageId = "Änderungsprotokoll"
Invoke-BCContainerApi -containerName $containerName `
                      -CompanyId $CompanyId `
                      -credential $credential `
                      -APIPublisher "microsoft" `
                      -APIGroup "automation" `
                      -APIVersion "v1.0" `
                      -Method "POST" `
                      -Query "configurationPackages"  -tenant default `
                      -body @{ "code" = $packageId; "packageName" = $packageId; } | Out-Null
```

Error:
```
Unable to translate bytes[*] at index * from specified code page to unicode.
```