### PR TITLE
exit function with 'return' instead of 'exit'

### DIFF
--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -48,7 +48,7 @@ function Setup-TraefikContainerForNavContainers {
 
         if (Test-Path -Path (Join-Path $traefikForBcBasePath "traefik.txt") -PathType Leaf) {
             Write-Host "Traefik container already initialized."
-            exit
+            return
         }
 
         if ($traefikToml -is [string]) {


### PR DESCRIPTION
The given 'exit' will couse the ISE to quit and the user will not be able to see the message that traefik is already initialized.
Maybe we should also change the Write-Host into a Write-Warning. What do you think?