### PR TITLE
Added Join-Path instead of "+" to prevent broken paths

### DIFF
--- a/ContainerInfo/Get-NavContainerPath.ps1
+++ b/ContainerInfo/Get-NavContainerPath.ps1
@@ -38,8 +38,8 @@ function Get-NavContainerPath {
         } else {
             $sharedFolders = Get-NavContainerSharedFolders -containerName $containerName
             $sharedFolders.GetEnumerator() | ForEach-Object {
-                if ($path -eq $_.Name -or ($containerPath -eq "" -and $path.StartsWith($_.Name+"\", "OrdinalIgnoreCase"))) {
-                    $containerPath = ($_.Value + $path.Substring($_.Name.Length))
+                if ($path -eq $_.Name -or ($containerPath -eq "" -and $path.StartsWith((Join-Path $_.Name "\"), "OrdinalIgnoreCase"))) {
+                    $containerPath = ((Join-Path $_.Value $path.Substring($_.Name.Length)))
                 }
             }
             if ($throw -and "$containerPath" -eq "") {


### PR DESCRIPTION
Get-NavContainerPath didnt find any paths, which were subfolders of a shared folder. The reason for that was, that in this case the comparison failed because a double backslash in the path added in line 41. See screenshot. 

![image](https://user-images.githubusercontent.com/23522177/68206948-36d84600-ffce-11e9-9c4d-c613fe07b7b2.png)
