### PR TITLE
Fix issue https://github.com/microsoft/navcontainerhelper/issues/765

### DIFF
--- a/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
+++ b/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
@@ -29,7 +29,7 @@ Function Convert-AlcOutputToAzureDevOps {
         foreach($line in $AlcOutput) {
             switch -regex ($line) {
                 "^warning (\w{2}\d{4}):(.*('.*').*|.*)$" {
-                    if (Test-Path $Matches[3]) {
+                    if ($null -ne $Matches[3]) {
                         Write-Host "##vso[task.logissue type=warning;sourcepath=$($Matches[3]);code=$($Matches[1]);]$($Matches[2])"
                     } else {
                         Write-Host "##vso[task.logissue type=warning;code=$($Matches[1]);]$($Matches[2])"


### PR DESCRIPTION
`Test-Path` with a null Path parameter fails with error `Cannot bind argument to parameter 'Path' because it is null.`

I don't really understand why `Test-Path $Matches[3]` is used. 
But if you wan't to check if there where 2 or 3 matches, checking if `$Matches[3]` is $null should be ok.

This is tested in my pipeline for `warning AS0055: The AppSourceCop configuration must specify the list of countries targeted by the application.` and it seems to do it's thing.