### PR TITLE
Fix Invoke-ScriptInNavContainer when running unelevated

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -104,6 +104,8 @@ Set-Location $runPath
             'if ($result) { [System.Management.Automation.PSSerializer]::Serialize($result) | Set-Content "'+$outputFile+'" }' | Add-Content $file
             docker exec $containerName powershell $file
             if($LASTEXITCODE -ne 0) {
+                Remove-Item $file -Force -ErrorAction SilentlyContinue
+                Remove-Item $outputFile -Force -ErrorAction SilentlyContinue
                 throw
             }
             if (Test-Path -Path $outputFile -PathType Leaf) {

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -103,6 +103,9 @@ Set-Location $runPath
             '$result = Invoke-Command -ScriptBlock {' + $scriptblock.ToString() + '} -ArgumentList $argumentList' | Add-Content $file
             'if ($result) { [System.Management.Automation.PSSerializer]::Serialize($result) | Set-Content "'+$outputFile+'" }' | Add-Content $file
             docker exec $containerName powershell $file
+            if($LASTEXITCODE -ne 0) {
+                throw
+            }
             if (Test-Path -Path $outputFile -PathType Leaf) {
                 [System.Management.Automation.PSSerializer]::Deserialize((Get-content $outputFile))
             }


### PR DESCRIPTION
When running Invoke-ScriptInNavContainer unelevated and the scriptblock fails, the Invoke- Script does not throw any error. This causes for example the Publish-NavContainerApp to report success when in fact it failed. 

Simply checking the `$LASTEXITCODE` should solve the issue but maybe theres a bether solution? 
It seems like docker exec is writing errors to stout instead of sterr?
