### PR TITLE
Fix illegal chars in app file name

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -150,7 +150,7 @@ function Compile-AppInNavContainer {
     $appJsonFile = Join-Path $appProjectFolder 'app.json'
     $appJsonObject = [System.IO.File]::ReadAllLines($appJsonFile) | ConvertFrom-Json
     if ("$appName" -eq "") {
-        $appName = "$($appJsonObject.Publisher.Replace('/',''))_$($appJsonObject.Name.Replace('/',''))_$($appJsonObject.Version).app"
+        $appName = "$($appJsonObject.Publisher)_$($appJsonObject.Name)_$($appJsonObject.Version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
     }
 
     Write-Host "Using Symbols Folder: $appSymbolsFolder"
@@ -290,9 +290,9 @@ function Compile-AppInNavContainer {
             $publisher = $dependency.publisher
             $name = $dependency.name
             $version = $dependency.version
-            $symbolsName = "$($publisher.Replace('/',''))_$($name.Replace('/',''))_$($version).app"
+            $symbolsName = "$($publisher)_$($name)_$($version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
             $publishedApps | Where-Object { $_.publisher -eq $publisher -and $_.name -eq $name } | % {
-                $symbolsName = "$($publisher.Replace('/',''))_$($name.Replace('/',''))_$($_.version).app"
+                $symbolsName = "$($publisher)_$($name)_$($_.version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
             }
             $symbolsFile = Join-Path $appSymbolsFolder $symbolsName
             Write-Host "Downloading symbols: $symbolsName"

--- a/AppHandling/Publish-NewApplicationToNavContainer.ps1
+++ b/AppHandling/Publish-NewApplicationToNavContainer.ps1
@@ -124,7 +124,7 @@ function Publish-NewApplicationToNavContainer {
             }
         }
         $installedApps | ForEach-Object {
-            $installedAppFile = Join-Path $appsFolder "$($_.Publisher.Replace('/',''))_$($_.Name.Replace('/',''))_$($_.Version).app"
+            $installedAppFile = Join-Path $appsFolder $("$($_.Publisher)_$($_.Name)_$($_.Version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join '')
             if ($restoreApps -eq "AsRuntimePackages") {
                 Write-Host "Downloading app $($_.Name) as runtime package"
                 Get-BCContainerAppRuntimePackage -containerName $containerName -appName $_.Name -publisher $_.Publisher -appVersion $_.Version -appFile $installedAppFile -Tenant default | Out-Null
@@ -147,7 +147,7 @@ function Publish-NewApplicationToNavContainer {
     if ($restoreApps -ne "No") {
         $installedApps | ForEach-Object {
             $installedApp = $_
-            $installedAppFile = Join-Path $appsFolder "$($installedApp.Publisher.Replace('/',''))_$($installedApp.Name.Replace('/',''))_$($installedApp.Version).app"
+            $installedAppFile = Join-Path $appsFolder $("$($installedApp.Publisher)_$($installedApp.Name)_$($installedApp.Version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join '')
             if ($_.IsPublished) {
                 try {
                     Publish-BCContainerApp -containerName $containerName -appFile $installedAppFile -skipVerification -sync -install:($installedApp.IsInstalled) -scope $Scope -useDevEndpoint:(!$doNotUseDevEndpoint) -replaceDependencies $replaceDependencies -credential $credential -ShowMyCode "Check"

--- a/AppHandling/Sort-AppFoldersByDependencies.ps1
+++ b/AppHandling/Sort-AppFoldersByDependencies.ps1
@@ -74,7 +74,8 @@ function Sort-AppFoldersByDependencies {
         }
         else {
             if (-not ($script:unresolvedDependencies | Where-Object { $_ -and $_.AppId -eq $dependency.AppId })) {
-                Write-Warning "Dependency $($dependency.appId):$($dependency.publisher.Replace('/',''))_$($dependency.name.Replace('/',''))_$($dependency.version)).app not found"
+                $appFileName = "$($dependency.publisher)_$($dependency.name)_$($dependency.version)).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+                Write-Warning "Dependency $($dependency.appId):$appFileName not found"
                 $script:unresolvedDependencies += @($dependency)
             }
         }
@@ -92,7 +93,8 @@ function Sort-AppFoldersByDependencies {
         ($folders[$_.id]).SubString($baseFolder.Length)
     }
     if ($unknownDependencies) {
-        $unknownDependencies.value = @($script:unresolvedDependencies | ForEach-Object { if ($_) { "$($_.appId):$($_.publisher.Replace('/',''))_$($_.name.Replace('/',''))_$($_.version).app" } })
+        $appFileName = "$($_.publisher)_$($_.name)_$($_.version).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+        $unknownDependencies.value = @($script:unresolvedDependencies | ForEach-Object { if ($_) { "$($_.appId):$appFileName" } })
     }
 }
 Export-ModuleMember -Function Sort-AppFoldersByDependencies

--- a/Tests/AppHandling.ps1
+++ b/Tests/AppHandling.ps1
@@ -46,22 +46,26 @@
         #TODO
     }
     It 'Extract-AppFileToFolder (nav app)' {
-        $navAppFile = Join-Path $navContainerPath "nav-app\output\$($appPublisher.Replace('/',''))_$($appName.Replace('/',''))_$($appVersion).app"
+        $navAppFileName = "$($appPublisher)_$($appName)_$($appVersion).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+        $navAppFile = Join-Path $navContainerPath "nav-app\output\$navAppFileName"
         Extract-AppFileToFolder $navAppFile -appFolder (Join-Path $navContainerPath "nav-app2")
         (Get-ChildItem -Path (Join-Path $navContainerPath "nav-app2\*.al") -Recurse).Count | Should -Be (Get-ChildItem -Path (Join-Path $navContainerPath "nav-app\*.al") -Recurse).Count
     }
     It 'Extract-AppFileToFolder (bc app)' {
-        $bcAppFile = Join-Path $bcContainerPath "bc-app\output\$($appPublisher.Replace('/',''))_$($appName.Replace('/',''))_$($appVersion).app"
+        $bcAppFileName = "$($appPublisher)_$($appName)_$($appVersion).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+        $bcAppFile = Join-Path $bcContainerPath "bc-app\output\$bcAppFileName"
         Extract-AppFileToFolder $bcAppFile -appFolder (Join-Path $bcContainerPath "bc-app2")
         (Get-ChildItem -Path (Join-Path $bcContainerPath "bc-app\*.al") -Recurse).Count | Should -Be (Get-ChildItem -Path (Join-Path $bcContainerPath "bc-app2\*.al") -Recurse).Count
 
     }
     It 'Publish-NavContainerApp' {
-        $navAppFile = Join-Path $navContainerPath "nav-app\output\$($appPublisher.Replace('/',''))_$($appName.Replace('/',''))_$($appVersion).app"
+        $navAppFileName = "$($appPublisher)_$($appName)_$($appVersion).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+        $navAppFile = Join-Path $navContainerPath "nav-app\output\$navAppFileName"
         Publish-NavContainerApp -containerName $navContainerName -appFile $navAppFile -skipVerification
     }
     It 'Publish-BcContainerApp' {
-        $bcAppFile = Join-Path $bcContainerPath "bc-app\output\$($appPublisher.Replace('/',''))_$($appName.Replace('/',''))_$($appVersion).app"
+        $bcAppFileName = "$($appPublisher)_$($appName)_$($appVersion).app".Split([System.IO.Path]::GetInvalidFileNameChars()) -join ''
+        $bcAppFile = Join-Path $bcContainerPath "bc-app\output\$bcAppFileName"
         Publish-BcContainerApp -containerName $bcContainerName -appFile $bcAppFile -skipVerification
     }
     It 'Sync-NavContainerApp' {


### PR DESCRIPTION
This modification prevents errors due to illegal characters in the app file name that occur when such characters are used in the app name.
Illegal characters are now simply removed from the app file name (which is in line with the behavior of the VSCode AL extension).