### PR TITLE
Bugfix PsTestFunctions.ps1, Function Get-Test

### DIFF
--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -204,7 +204,7 @@ function Get-Tests {
 				Write-Debug $("[Row Index: " + $rowIndex + " (Index: " + $index + ", Offset: " + $repeaterOffset + ") ] Nothing found.")
 			}
 			
-			if ($rowIndex -ge ($originalRepeaterOffset - 1))
+			if (($rowIndex -ge ($originalRepeaterOffset - 1)) -and ($originalRepeaterOffset -ne 0))
 			{
 				Write-Debug "+1 Scroll Repeater ."
 				$clientContext.ScrollRepeater($repeater, 1)
@@ -214,6 +214,7 @@ function Get-Tests {
 	}
 
     $index = 0
+	$repeaterCount = [int]$repeater.DefaultViewport.Count
 	if ($repeaterOffset -gt 0) {
 		$repeaterCount = $repeaterCount + $repeaterOffset
 		$repeaterOffset = 0
@@ -274,7 +275,7 @@ function Get-Tests {
             }
 		}
 		
-		if ($rowIndex -ge ($originalRepeaterOffset - 1))
+		if (($rowIndex -ge ($originalRepeaterOffset - 1)) -and ($originalRepeaterOffset -ne 0))
 		{
 			$clientContext.ScrollRepeater($repeater, 1)
 			$repeaterOffset = $repeaterOffset + $originalRepeaterOffset

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -167,25 +167,68 @@ function Get-Tests {
 
     $repeater = $clientContext.GetControlByType($form, [ClientRepeaterControl])
     $index = 0
-    $repeaterCount = [int]$repeater.DefaultViewport.Count
+	$repeaterCount = [int]$repeater.DefaultViewport.Count
 	$repeaterOffset = [int]$repeater.Offset
 	$originalRepeaterOffset = [int]$repeater.Offset
+	if ($debugMode) {	
+		Write-Debug "No. of Records: $repeaterCount"
+		Write-Debug "Repeater Offset: $repeaterOffset"
+	}
+	if ($repeaterOffset -gt 0) {
+		$repeaterCount = $repeaterCount + $repeaterOffset
+		$repeaterOffset = 0
+		Write-Debug "-1 Scroll Repeater."
+		$clientContext.ScrollRepeater($repeater, -1)		
+	}
+	
+	if ($debugMode) {	
+		Write-Debug "Iterate through Repeater control..."	
+		while ($true)
+		{
+			$rowIndex = $index - $repeaterOffset
+			$index++
+			if ($index -ge $repeaterCount)
+			{
+				Write-Debug $("[Row Index: " + $rowIndex + " (Index: " + $index + ", Offset: " + $repeaterOffset + ") ] Repeater finished.")
+				break 
+			}
+			$row = $repeater.DefaultViewport[$rowIndex]
+			$lineTypeControl = $clientContext.GetControlByName($row, "LineType")
+			$lineType = "$(([int]$lineTypeControl.StringValue) + $lineTypeAdjust)"
+			$name = $clientContext.GetControlByName($row, "Name").StringValue
+			$codeUnitId = $clientContext.GetControlByName($row, "TestCodeunit").StringValue
+
+			if ($name) {
+				Write-Debug $("[Row Index: " + $rowIndex + " (Index: " + $index + ", Offset: " + $repeaterOffset + ") ] " + $name + " (Line Type: " + $linetype + ")")
+			} else {
+				Write-Debug $("[Row Index: " + $rowIndex + " (Index: " + $index + ", Offset: " + $repeaterOffset + ") ] Nothing found.")
+			}
+			
+			if ($rowIndex -ge ($originalRepeaterOffset - 1))
+			{
+				Write-Debug "+1 Scroll Repeater ."
+				$clientContext.ScrollRepeater($repeater, 1)
+				$repeaterOffset = $repeaterOffset + $originalRepeaterOffset
+			}
+		}
+	}
+
+    $index = 0
 	if ($repeaterOffset -gt 0) {
 		$repeaterCount = $repeaterCount + $repeaterOffset
 		$repeaterOffset = 0
 		$clientContext.ScrollRepeater($repeater, -1)		
 	}
-
     $Tests = @()
     $group = $null
     while ($true)
     {
 		$rowIndex = $index - $repeaterOffset
-        $index++
+		$index++
 		if ($index -ge $repeaterCount)
-        {
-            break 
-        }
+		{
+			break 
+		}
         $row = $repeater.DefaultViewport[$rowIndex]
         $lineTypeControl = $clientContext.GetControlByName($row, "LineType")
         $lineType = "$(([int]$lineTypeControl.StringValue) + $lineTypeAdjust)"
@@ -229,7 +272,7 @@ function Get-Tests {
                     }
                 }
             }
-        }
+		}
 		
 		if ($rowIndex -ge ($originalRepeaterOffset - 1))
 		{

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -169,6 +169,7 @@ function Get-Tests {
     $index = 0
     $repeaterCount = [int]$repeater.DefaultViewport.Count
 	$repeaterOffset = [int]$repeater.Offset
+	$originalRepeaterOffset = [int]$repeater.Offset
 	if ($repeaterOffset -gt 0) {
 		$repeaterCount = $repeaterCount + $repeaterOffset
 		$repeaterOffset = 0


### PR DESCRIPTION
As described in Issue #944 there is a problem in PsTestFunctions.ps1 in handling the repeater offset correctly. The problem seems only to occur if more than 15 tests are existing.

With the code modifications I was able to run pipelines with more and less than 15 tests included. Tested with 12 build pipelines and BC16 (sandbox).

The console output has been changed to this:
![image](https://user-images.githubusercontent.com/39621236/79356382-2cd44f00-7f3f-11ea-9f49-a88e94da7f50.png)
![image](https://user-images.githubusercontent.com/39621236/79360525-58a60380-7f44-11ea-95e1-cde95ffac622.png)
