### PR TITLE
Update Get-NavContainerSharedFolders.ps1

### DIFF
--- a/ContainerInfo/Get-NavContainerSharedFolders.ps1
+++ b/ContainerInfo/Get-NavContainerSharedFolders.ps1
@@ -26,7 +26,7 @@ function Get-NavContainerSharedFolders {
         if ($inspect.HostConfig.Binds) {
             $inspect.HostConfig.Binds | ForEach-Object {
                 $idx = $_.IndexOf(':', $_.IndexOf(':') + 1)
-                $src = $_.Substring(0, $idx)
+                $src = $_.Substring(0, $idx).TrimEnd('\')
                 $dst = $_.SubString($idx+1)
                 $idx = $dst.IndexOf(':', $_.IndexOf(':') + 1)
                 if ($idx -gt 0) {


### PR DESCRIPTION
A path is displayed twice if a path with backlash at the end is specified at container start. The optional removal of the backlsash ensures that the function returns the correct paths independently.
**Before:**
![image](https://user-images.githubusercontent.com/23522177/83649489-8c51f100-a5b7-11ea-9d45-7a1a88419177.png)
**After:**
![image](https://user-images.githubusercontent.com/23522177/83649562-a25fb180-a5b7-11ea-807b-a1b4cca6b9bd.png)
