### PR TITLE
pre download and move cache

### DIFF
--- a/ContainerHandling/Flush-ContainerHelperCache.ps1
+++ b/ContainerHandling/Flush-ContainerHelperCache.ps1
@@ -16,7 +16,7 @@
 function Flush-ContainerHelperCache {
     [CmdletBinding()]
     Param (
-        [ValidateSet('all','calSourceCache','alSourceCache','applicationCache','bakFolderCache','filesCache','downloadsCache')]
+        [ValidateSet('all','calSourceCache','alSourceCache','applicationCache','bakFolderCache','filesCache','bcartifacts')]
         [string] $cache = 'all'
     )
 
@@ -29,8 +29,11 @@ function Flush-ContainerHelperCache {
         $folders += @("*-??-files")
     }
 
-    if ($cache -eq 'all' -or $cache -eq 'downloadsCache') {
-        $folders += @("downloads")
+    if ($cache -eq 'all' -or $cache -eq 'bcartifacts') {
+        Get-ChildItem -Path 'c:\bcartifacts.cache' | ?{ $_.PSIsContainer } | ForEach-Object {
+            Write-Host "Removing Cache $($_.FullName)"
+            [System.IO.Directory]::Delete($_.FullName, $true)
+        }
     }
 
     if ($cache -eq 'all' -or $cache -eq 'alSourceCache') {
@@ -47,9 +50,9 @@ function Flush-ContainerHelperCache {
 
     $folders | ForEach-Object {
         $folder = Join-Path $hostHelperFolder $_
-        Get-Item $folder | ?{ $_.PSIsContainer } | ForEach-Object {
+        Get-Item $folder -ErrorAction SilentlyContinue | ?{ $_.PSIsContainer } | ForEach-Object {
             Write-Host "Removing Cache $($_.FullName)"
-            Remove-Item -Path $_.FullName -Recurse -Force
+            [System.IO.Directory]::Delete($_.FullName, $true)
         }
     }
 }

--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -254,7 +254,7 @@ function New-NavImage {
         Write-Host "Using Platform Artifacts from $platformArtifactPath"
         
         if (-not (Test-Path $platformArtifactPath)) {
-            Write-Host "Downloading platform artifact $($platformUri.AbsolutePath) - $platformUrl"
+            Write-Host "Downloading platform artifact $($platformUri.AbsolutePath)"
             $platformZip = Join-Path $buildFolder "platform.zip"
             Download-File -sourceUrl $platformUrl -destinationFile $platformZip
             Write-Host "Unpacking platform artifact"
@@ -274,7 +274,6 @@ function New-NavImage {
                             New-Item -Path $dirName -ItemType Directory | Out-Null
                         }
                         $url = $_.Value
-                        Write-Host "Downloading $filename from $url"
                         Download-File -sourceUrl $url -destinationFile $path
                     }
                 }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,8 @@ New-BcContainer will automatically build anc cache an image if ImageName and Art
 Add environment variable ArtifactUrl to image in New-BcImage
 new-BcImage deletes the image if it already exists
 New function Get-BCContainerArtifactUrl to get the ArtifactUrl used to create a container
+Move Artfacts cache to c:\bcartifacts.cache due to filename lengths above 260
+Pre-download platform artifact in containerHelper before starting container to avoid dns problems
 
 0.7.0.0
 Add new function New-BcImage to create an image based on artifacts


### PR DESCRIPTION
Move Artfacts cache to c:\bcartifacts.cache due to filename lengths above 260
Pre-download platform artifact in containerHelper before starting container to avoid dns problems