### PR TITLE
0.7.0.12

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -266,8 +266,33 @@ function Compile-AppInNavContainer {
         [SslVerification]::Disable()
     }
     
+$Source = @"
+	using System.Net;
+ 
+	public class TimeoutWebClient : WebClient
+	{
+        int theTimeout;
 
-    $webClient = [System.Net.WebClient]::new()
+        public TimeoutWebClient(int timeout)
+        {
+            theTimeout = timeout;
+        }
+
+		protected override WebRequest GetWebRequest(System.Uri address)
+		{
+			WebRequest request = base.GetWebRequest(address);
+			if (request != null)
+			{
+				request.Timeout = theTimeout;
+			}
+			return request;
+		}
+ 	}
+"@;
+ 
+    Add-Type -TypeDefinition $Source -Language CSharp -WarningAction SilentlyContinue | Out-Null
+
+    $webClient = [TimeoutWebClient]::new(300000)
     if ($customConfig.ClientServicesCredentialType -eq "Windows") {
         $webClient.UseDefaultCredentials = $true
     }

--- a/ContainerHandling/Import-NavContainerLicense.ps1
+++ b/ContainerHandling/Import-NavContainerLicense.ps1
@@ -46,7 +46,7 @@ function Import-NavContainerLicense {
         
         if ($restart) {
             Write-Host "Restarting Service Tier"
-            Set-NavServerInstance ServerInstance $ServerInstance -restart
+            Set-NavServerInstance -ServerInstance $ServerInstance -restart
         }
     
     }  -ArgumentList (Get-NavContainerPath -ContainerName $containerName -Path $containerLicenseFile), $restart

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -363,7 +363,10 @@ function New-NavContainer {
     if ($imageName -ne "") {
         if ($artifactUrl -eq "") {
             if ($imageName -like "mcr.microsoft.com/*") {
-                Write-Host -ForegroundColor Red "WARNING: You are running specific Docker images Microsoft container registries. These images will no longer be updated, you should switch to user Docker artifacts. See https://freddysblog.com/2020/07/05/july-updates-are-out-they-are-the-last-on-premises-docker-images/"
+                Write-Host -ForegroundColor Red "WARNING: You are running specific Docker images from mcr.microsoft.com. These images will no longer be updated, you should switch to user Docker artifacts. See https://freddysblog.com/2020/07/05/july-updates-are-out-they-are-the-last-on-premises-docker-images/"
+            }
+            if ($imageName -like "bcinsider.azurecr.io/*") {
+                Write-Host -ForegroundColor Red "WARNING: You are running specific Docker images from bcinsider.azurecr.io. These images will no longer be updated, you should switch to user Docker artifacts. See https://freddysblog.com/2020/07/05/july-updates-are-out-they-are-the-last-on-premises-docker-images/"
             }
         }
         else {

--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -81,9 +81,9 @@ function New-NavImage {
         if ("$baseImage" -eq "") {
             throw "Unable to find matching generic image for your host OS. You must pull and specify baseImage manually."
         }
+        Write-Host "Pulling latest image $baseImage"
+        DockerDo -command pull -imageName $baseImage | Out-Null
     }
-    Write-Host "Pulling latest image $baseImage"
-    DockerDo -command pull -imageName $baseImage | Out-Null
 
     $genericTag = [Version](Get-NavContainerGenericTag -containerOrImageName $baseImage)
     Write-Host "Generic Tag: $genericTag"

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 0.7.0.12
 Ensure that host.containerhelper.internal is set inside the container even if -updatehosts isn't used
+Do not use docker pull when calling New-BcImage with a BaseImage
 
 0.7.0.11
 Issue #1068 New-BcImage doesn't run on Windows Server 2016

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 0.7.0.12
 Ensure that host.containerhelper.internal is set inside the container even if -updatehosts isn't used
 Do not use docker pull when calling New-BcImage with a BaseImage
+Issue #1077 Increase timeout for downloading symbols
 
 0.7.0.11
 Issue #1068 New-BcImage doesn't run on Windows Server 2016


### PR DESCRIPTION
Ensure that host.containerhelper.internal is set inside the container even if -updatehosts isn't used
Do not use docker pull when calling New-BcImage with a BaseImage
Issue #1077 Increase timeout for downloading symbols