### PR TITLE
0.7.0.14

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -232,6 +232,13 @@ function New-NavContainer {
         [scriptblock] $finalizeDatabasesScriptBlock
     )
 
+    $navcontainerhelperConfig.defaultContainerParameters.GetEnumerator() | % {
+        if (!($PSBoundParameters.ContainsKey($_.Name))) {
+            Write-Host "Default parameter $($_.Name) = $($_.Value)"
+            Set-Variable -name $_.Name -Value $_.Value
+        }        
+    }
+
     if (!$accept_eula) {
         throw "You have to accept the eula (See https://go.microsoft.com/fwlink/?linkid=861843) by specifying the -accept_eula switch to the function"
     }

--- a/CreateScript.ps1
+++ b/CreateScript.ps1
@@ -806,6 +806,9 @@ if ($hosting -eq "Local") {
         if ($filename -notlike "*.ps1") {
             $filename += ".ps1"
         }
+        if ($filename.indexOf('\') -eq -1) {
+            $filename = Join-Path ([environment]::getfolderpath(“mydocuments”)) $filename
+        }
         $script | Out-File $filename
         start -Verb Edit $filename
     }

--- a/NavContainerHelper.psm1
+++ b/NavContainerHelper.psm1
@@ -42,6 +42,7 @@ $navContainerHelperConfig = @{
     "bcartifactsCacheFolder" = "c:\bcartifacts.cache"
     "genericImageName" = 'mcr.microsoft.com/dynamicsnav:{0}-generic'
     "usePsSession" = $isAdministrator
+    "defaultNewContainerParameters" = @{ }
 }
 
 $navContainerHelperConfigFile = Join-Path $containerHelperFolder "NavContainerHelper.config.json"

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,7 @@
 0.7.0.14
 Issue #1088 Concurrency issues in NavContainerHelper
+Added default path to filename in New-BcContainerWizard
+Added default parameters for NewContainer (example $navContainerHelperConfig.defaultNewContainerParameters = @{ "updatehosts" = $true })
 
 0.7.0.13
 Get-BestNavContainerImageName didn't work in 0.7.0.12


### PR DESCRIPTION
Issue #1088 Concurrency issues in NavContainerHelper
Added default path to filename in New-BcContainerWizard
Added default parameters for NewContainer (example $navContainerHelperConfig.defaultNewContainerParameters = @{ "updatehosts" = $true })
