### PR TITLE
Use 7zip if exist to expand archive

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -173,7 +173,7 @@ function Compile-AppInNavContainer {
         if (!(Test-Path "c:\build" -PathType Container)) {
             $tempZip = Join-Path $env:TEMP "alc.zip"
             Copy-item -Path (Get-Item -Path "c:\run\*.vsix").FullName -Destination $tempZip
-            Expand-Archive -Path $tempZip -DestinationPath "c:\build\vsix"
+            Expand-7zipArchive -Path $tempZip -DestinationPath "c:\build\vsix"
         }
     }
 

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -173,7 +173,7 @@ function Compile-AppInNavContainer {
         if (!(Test-Path "c:\build" -PathType Container)) {
             $tempZip = Join-Path $env:TEMP "alc.zip"
             Copy-item -Path (Get-Item -Path "c:\run\*.vsix").FullName -Destination $tempZip
-            Expand-7zipArchive -Path $tempZip -DestinationPath "c:\build\vsix"
+            Expand-Archive -Path $tempZip -DestinationPath "c:\build\vsix"
         }
     }
 

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -670,7 +670,7 @@ function New-NavContainer {
         $tempFile = "$tempFolder.zip"
         Download-File -sourceUrl $dvdPath -destinationFile $tempFile
         Write-Host "Extracting DVD .zip file"
-        Expand-Archive -Path $tempFile -DestinationPath $tempFolder
+        Expand-7zipArchive -Path $tempFile -DestinationPath $tempFolder
         Remove-Item -Path $tempFile
         $dvdPath = $tempFolder
     }
@@ -678,7 +678,7 @@ function New-NavContainer {
         $temp = Join-Path $containerFolder "NAVDVD"
         new-item -type directory -Path $temp | Out-Null
         Write-Host "Extracting DVD .zip file"
-        Expand-Archive -Path $dvdPath -DestinationPath $temp
+        Expand-7zipArchive -Path $dvdPath -DestinationPath $temp
         $dvdPath = $temp
     }
 
@@ -1045,14 +1045,14 @@ function New-NavContainer {
                 Download-File -sourceUrl $_ -destinationFile $destinationFile
                 if ($destinationFile.EndsWith(".zip", "OrdinalIgnoreCase")) {
                     Write-Host "Extracting .zip file"
-                    Expand-Archive -Path $destinationFile -DestinationPath $myFolder
+                    Expand-7zipArchive -Path $destinationFile -DestinationPath $myFolder
                     Remove-Item -Path $destinationFile -Force
                 }
             } elseif (Test-Path $_ -PathType Container) {
                 Copy-Item -Path "$_\*" -Destination $myFolder -Recurse -Force
             } else {
                 if ($_.EndsWith(".zip", "OrdinalIgnoreCase")) {
-                    Expand-Archive -Path $_ -DestinationPath $myFolder
+                    Expand-7zipArchive -Path $_ -DestinationPath $myFolder
                 } else {
                     Copy-Item -Path $_ -Destination $myFolder -Force
                 }
@@ -1591,7 +1591,7 @@ if (-not `$restartingInstance) {
         Write-Host "Downloading new test apps for this version from $url"
         $zipName = Join-Path $containerFolder "16.0.11240.12076-$devCountry-Tests-Patch"
         Download-File -sourceUrl $url -destinationFile "$zipName.zip"
-        Expand-Archive "$zipName.zip" -DestinationPath $zipname -Force
+        Expand-7zipArchive -Path "$zipName.zip" -DestinationPath $zipname
         Write-Host "Patching .app files in C:\Applications\BaseApp\Test due to issue #925"
         Invoke-ScriptInNavContainer -containerName $containerName -scriptblock { Param($zipName, $devCountry)
             Copy-Item -Path (Join-Path $zipName "$devCountry\*.app") -Destination "c:\Applications\BaseApp\Test" -Force

--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -173,14 +173,14 @@ function New-NavImage {
                     Download-File -sourceUrl $_ -destinationFile $destinationFile
                     if ($destinationFile.EndsWith(".zip", "OrdinalIgnoreCase")) {
                         Write-Host "Extracting .zip file"
-                        Expand-Archive -Path $destinationFile -DestinationPath $myFolder
+                        Expand-7zipArchive -Path $destinationFile -DestinationPath $myFolder
                         Remove-Item -Path $destinationFile -Force
                     }
                 } elseif (Test-Path $_ -PathType Container) {
                     Copy-Item -Path "$_\*" -Destination $myFolder -Recurse -Force
                 } else {
                     if ($_.EndsWith(".zip", "OrdinalIgnoreCase")) {
-                        Expand-Archive -Path $_ -DestinationPath $myFolder
+                        Expand-7zipArchive -Path $_ -DestinationPath $myFolder
                     } else {
                         Copy-Item -Path $_ -Destination $myFolder -Force
                     }

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -227,3 +227,22 @@ function TestSasToken {
         }
     }
 }
+
+function Expand-7zipArchive {
+    Param (
+        [Parameter(Mandatory=$true)]
+        [string] $Path,
+        [string] $DestinationPath
+    )
+
+    $7zipPath = "$env:ProgramFiles\7-Zip\7z.exe"
+
+    if (-not (Test-Path -Path $7zipPath -PathType Leaf)) {
+        Write-Host "7zip tool not found, continue using Expand-Archive"
+        Expand-Archive -Path $Path -DestinationPath "$DestinationPath" -Force
+    } else {
+        Set-Alias -Name 7z -Value $7zipPath
+        $command = '7z x "{0}" -o"{1}" -aoa -r' -f $Path,$DestinationPath
+        Invoke-Expression -Command $command
+    }
+}

--- a/Misc/Download-Artifacts.ps1
+++ b/Misc/Download-Artifacts.ps1
@@ -90,7 +90,7 @@ function Download-Artifacts {
                 Write-Host "Unpacking application artifact to tmp folder"
                 $tmpFolder = Join-Path ([System.IO.Path]::GetDirectoryName($appArtifactPath)) "tmp$(([datetime]::Now).Ticks)"
                 try {
-                    Expand-Archive -Path $appZip -DestinationPath $tmpFolder -Force
+                    Expand-7zipArchive -Path $appZip -DestinationPath $tmpFolder
                     if (!(Test-Path "$appArtifactPath")) {
                         Rename-Item -Path "$tmpFolder" -NewName ([System.IO.Path]::GetFileName($appArtifactPath)) -Force -ErrorAction SilentlyContinue
                     }
@@ -169,7 +169,7 @@ function Download-Artifacts {
                     Write-Host "Unpacking platform artifact to tmp folder"
                     $tmpFolder = Join-Path ([System.IO.Path]::GetDirectoryName($platformArtifactPath)) "tmp$(([datetime]::Now).Ticks)"
                     try {
-                        Expand-Archive -Path $platformZip -DestinationPath $tmpFolder -Force
+                        Expand-7zipArchive -Path $platformZip -DestinationPath $tmpFolder
                         if (!(Test-Path "$platformArtifactPath")) {
                             Rename-Item -Path "$tmpFolder" -NewName ([System.IO.Path]::GetFileName($platformArtifactPath)) -Force -ErrorAction SilentlyContinue
                             $prerequisiteComponentsFile = Join-Path $platformArtifactPath "Prerequisite Components.json"

--- a/ObjectHandling/Convert-Txt2Al.ps1
+++ b/ObjectHandling/Convert-Txt2Al.ps1
@@ -80,7 +80,7 @@ function Convert-Txt2Al {
                     if (!(Test-Path "c:\build" -PathType Container)) {
                         $tempZip = Join-Path $env:TEMP "alc.zip"
                         Copy-item -Path (Get-Item -Path "c:\run\*.vsix").FullName -Destination $tempZip
-                        Expand-Archive -Path $tempZip -DestinationPath "c:\build\vsix"
+                        Expand-7zipArchive -Path $tempZip -DestinationPath "c:\build\vsix"
                     }
                     $alcPath = 'C:\build\vsix\extension\bin'
                     Copy-Item -Path (Join-Path $alcPath "Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll") -Destination ([System.IO.Path]::GetDirectoryName($txt2al))

--- a/ObjectHandling/Convert-Txt2Al.ps1
+++ b/ObjectHandling/Convert-Txt2Al.ps1
@@ -80,7 +80,7 @@ function Convert-Txt2Al {
                     if (!(Test-Path "c:\build" -PathType Container)) {
                         $tempZip = Join-Path $env:TEMP "alc.zip"
                         Copy-item -Path (Get-Item -Path "c:\run\*.vsix").FullName -Destination $tempZip
-                        Expand-7zipArchive -Path $tempZip -DestinationPath "c:\build\vsix"
+                        Expand-Archive -Path $tempZip -DestinationPath "c:\build\vsix"
                     }
                     $alcPath = 'C:\build\vsix\extension\bin'
                     Copy-Item -Path (Join-Path $alcPath "Microsoft.Dynamics.Nav.CodeAnalysis.Workspaces.dll") -Destination ([System.IO.Path]::GetDirectoryName($txt2al))


### PR DESCRIPTION
For better performance use of 7zip instead of Expand-Archive when it's possible - on Azure and GitHub hosted Agents 7zip is installed by default.

I tested it to expand platform artifact and get following result:

- Using Expand-Archive - 57 seconds
- Using Expand-7zipArchive - 8 seconds

In case that 7zip tool is not found - system will use standard Expand-Archive function.