### PR TITLE
Remove check for clientservicesport

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -598,7 +598,7 @@ function New-BcContainer {
         }
 
         if ($PublishPorts.Count -gt 0 -or
-            $WebClientPort -or $FileSharePort -or $ManagementServicesPort -or $ClientServicesPort -or 
+            $WebClientPort -or $FileSharePort -or $ManagementServicesPort -or 
             $SoapServicesPort -or $ODataServicesPort -or $DeveloperServicesPort) {
             throw "When using Traefik, all external communication comes in through port 443, so you can't change the ports"
         }


### PR DESCRIPTION
Since Client Services are not mapped via Traefik we should be able to specify the port we want to use.