### PR TITLE
AppFiles and PreviousApps fix

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -761,6 +761,9 @@ Write-Host -ForegroundColor Yellow @'
                             $AppList += @($tmpFile)
                         }
                     }
+                    else {
+                        $AppList += @($_)
+                    }
                 }
                 $previousApps = Sort-AppFilesByDependencies -appFiles $appList
                 $previousApps | ForEach-Object {

--- a/AppHandling/Sort-AppFilesByDependencies.ps1
+++ b/AppHandling/Sort-AppFilesByDependencies.ps1
@@ -12,11 +12,15 @@
 #>
 function Sort-AppFilesByDependencies {
     Param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [string[]] $appFiles,
         [Parameter(Mandatory=$false)]
         [ref] $unknownDependencies
     )
+
+    if (!$appFiles) {
+        return @()
+    }
 
     # Read all app.json objects, populate $apps
     $apps = $()

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,9 @@ Issue #1369 wrong validateset on tenant
 Issue #1371 missing quotes on volume parameter
 Check all countries when determining artifacts to use
 Issue #1380 Import-TestToolkitToBcContainer fails when license warning occurs
+Issue 1377 Sort-AppFoldersByDependencies didn't support empty arrays
+Allow AppFiles to be an empty array in Sort-AppFilesByDependencies
+Allow previousApps to be present locally (not downloaded from http or https)
 
 1.0.9
 Fix issue when setting bccontainerhelperconfig.defaultnewcontainerparameters.credential in the same session as using it


### PR DESCRIPTION
Allow AppFiles to be an empty array in Sort-AppFilesByDependencies
Allow previousApps to be present locally (not downloaded from http or https)
