### PR TITLE
Dev

### DIFF
--- a/AppHandling/Get-TestsFromNavContainer.ps1
+++ b/AppHandling/Get-TestsFromNavContainer.ps1
@@ -12,6 +12,8 @@
   profile to use
  .Parameter credential
   Credentials of the SUPER user if using NavUserPassword authentication
+ .Parameter sqlcredential
+  SQL Credential if using an external sql server
  .Parameter accesstoken
   If your container is running AAD authentication, you need to specify an accesstoken for the user specified in credential
  .Parameter testSuite
@@ -46,6 +48,8 @@ function Get-TestsFromBcContainer {
         [string] $profile = "",
         [Parameter(Mandatory=$false)]
         [PSCredential] $credential = $null,
+        [Parameter(Mandatory=$false)]
+        [PSCredential] $sqlCredential = $credential,
         [Parameter(Mandatory=$false)]
         [string] $accessToken = "",
         [Parameter(Mandatory=$false)]
@@ -123,7 +127,7 @@ function Get-TestsFromBcContainer {
                 if ($clientServicesCredentialType -eq "Windows") {
                     Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile
                 } else {
-                    Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile -sqlCredential $credential
+                    Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile -sqlCredential $sqlCredential
                 }
             }
         } catch {

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -12,6 +12,8 @@
   profile to use
  .Parameter credential
   Credentials of the SUPER user if using NavUserPassword authentication
+ .Parameter sqlcredential
+  SQL Credential if using an external sql server
  .Parameter accesstoken
   If your container is running AAD authentication, you need to specify an accesstoken for the user specified in credential
  .Parameter testSuite
@@ -73,6 +75,8 @@ function Run-TestsInBcContainer {
         [string] $profile = "",
         [Parameter(Mandatory=$false)]
         [PSCredential] $credential = $null,
+        [Parameter(Mandatory=$false)]
+        [PSCredential] $sqlCredential = $credential,
         [Parameter(Mandatory=$false)]
         [string] $accessToken = "",
         [Parameter(Mandatory=$false)]
@@ -181,7 +185,7 @@ function Run-TestsInBcContainer {
                 if ($clientServicesCredentialType -eq "Windows") {
                     Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile
                 } else {
-                    Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile -sqlCredential $credential
+                    Import-ObjectsToNavContainer -containerName $containerName -objectsFile $fobfile -sqlCredential $sqlCredential
                 }
             }
         } catch {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -304,6 +304,13 @@ function New-BcContainer {
         throw "You have to accept the eula (See https://go.microsoft.com/fwlink/?linkid=861843) by specifying the -accept_eula switch to the function"
     }
 
+    if ($includePerformanceToolkit) {
+        if (!$includeTestToolkit) {
+            $includeTestToolkit = $true
+            $includeTestFrameworkOnly = $true
+        }
+    }
+
     Check-BcContainerName -ContainerName $containerName
     $imageName = $imageName.ToLowerInvariant()
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -7,6 +7,7 @@ Add parameter -PublisherAzureActiveDirectoryTenantId to Publish-BcContainerApp
 New function Restore-BcDatabaseFromArtifacts for restoring databases from artifacts on an external sql server
 New function Remove-BcDatabase for removing databases from an external sql server
 New parameters -databasePrefix and -replaceExternalDatabases to New-BcContainer to allow New-BcContainer to create/replace databases on external SQL Server
+Add parameters -databaseCredential and -compress to Backup-BcContainerDatabases
 
 1.0.12
 Issue #1401 set app version if appBuild -or appRevision is specified

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -10,6 +10,7 @@ New parameters -databasePrefix and -replaceExternalDatabases to New-BcContainer 
 Issue #1417 Add parameters -databaseCredential and -compress to Backup-BcContainerDatabases
 Issue #1416 Add parameter -sqlCredential to Run-TestsInBcContainer and Get-TestsFromBcContainer if using external SQL Server
 Issue #1415 Implicitely import the Test Framework in Setup-BcContainerTestUsers if not already installed
+Issue #1426 includePerformanceToolkit should automatically include includeTestToolkit and includeTestFrameWorkOnly (if not specified)
 
 1.0.12
 Issue #1401 set app version if appBuild -or appRevision is specified

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -12,6 +12,7 @@ Issue #1416 Add parameter -sqlCredential to Run-TestsInBcContainer and Get-Tests
 Issue #1415 Implicitely import the Test Framework in Setup-BcContainerTestUsers if not already installed
 Issue #1426 includePerformanceToolkit should automatically include includeTestToolkit and includeTestFrameWorkOnly (if not specified)
 Publishing apps from a .zip file, where the name isn't .zip caused an error
+Add parameter gitLab to Run-AlPipeline to add support for surfacing test errors on GitLab
 
 1.0.12
 Issue #1401 set app version if appBuild -or appRevision is specified

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -11,6 +11,7 @@ Issue #1417 Add parameters -databaseCredential and -compress to Backup-BcContain
 Issue #1416 Add parameter -sqlCredential to Run-TestsInBcContainer and Get-TestsFromBcContainer if using external SQL Server
 Issue #1415 Implicitely import the Test Framework in Setup-BcContainerTestUsers if not already installed
 Issue #1426 includePerformanceToolkit should automatically include includeTestToolkit and includeTestFrameWorkOnly (if not specified)
+Publishing apps from a .zip file, where the name isn't .zip caused an error
 
 1.0.12
 Issue #1401 set app version if appBuild -or appRevision is specified

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -7,7 +7,9 @@ Add parameter -PublisherAzureActiveDirectoryTenantId to Publish-BcContainerApp
 New function Restore-BcDatabaseFromArtifacts for restoring databases from artifacts on an external sql server
 New function Remove-BcDatabase for removing databases from an external sql server
 New parameters -databasePrefix and -replaceExternalDatabases to New-BcContainer to allow New-BcContainer to create/replace databases on external SQL Server
-Add parameters -databaseCredential and -compress to Backup-BcContainerDatabases
+Issue #1417 Add parameters -databaseCredential and -compress to Backup-BcContainerDatabases
+Issue #1416 Add parameter -sqlCredential to Run-TestsInBcContainer and Get-TestsFromBcContainer if using external SQL Server
+Issue #1415 Implicitely import the Test Framework in Setup-BcContainerTestUsers if not already installed
 
 1.0.12
 Issue #1401 set app version if appBuild -or appRevision is specified

--- a/UserHandling/Setup-NavContainerTestUsers.ps1
+++ b/UserHandling/Setup-NavContainerTestUsers.ps1
@@ -90,7 +90,7 @@ function Setup-BcContainerTestUsers {
                     get-childitem -Path "C:\Applications\*.*" -recurse -filter "Microsoft_System Application Test Library.app"
                 }
                 if ($testAppFile) {
-                    Publish-BcContainerApp -containerName $containerName -tenant $tenant -appFile ":$testAppFile" -skipVerification -sync -install -replaceDependencies $replaceDependencies
+                    Publish-BcContainerApp -containerName $containerName -tenant $tenant -appFile ":$testAppFile" -skipVerification -sync -install -replaceDependencies $replaceDependencies 
                 }
             }
             if ($createTestUsersAppUrl -eq '') {
@@ -104,8 +104,7 @@ function Setup-BcContainerTestUsers {
             $select = ''
         }
 
-        Download-File -sourceUrl $createTestUsersAppUrl -destinationFile $appfile
-        Publish-BcContainerApp -containerName $containerName -tenant $tenant -appFile $appFile -skipVerification -install -sync -replaceDependencies $replaceDependencies
+        Publish-BcContainerApp -containerName $containerName -tenant $tenant -appFile $createTestUsersAppUrl -skipVerification -install -sync -replaceDependencies $replaceDependencies
 
         $companyId = Get-BcContainerApiCompanyId -containerName $containerName -tenant $tenant -credential $credential
 

--- a/UserHandling/Setup-NavContainerTestUsers.ps1
+++ b/UserHandling/Setup-NavContainerTestUsers.ps1
@@ -74,7 +74,7 @@ function Setup-BcContainerTestUsers {
 
         $appfile = Join-Path $env:TEMP "CreateTestUsers.app"
         if (([System.Version]$version).Major -ge 15) {
-
+            Import-TestToolkitToBcContainer -containerName $containerName -tenant $tenant -includeTestFrameworkOnly -replaceDependencies $replaceDependencies -doNotUseRuntimePackages
             $systemAppTestLibrary = get-BcContainerappinfo -containername $containerName -tenant $tenant | Where-Object { $_.Name -eq "System Application Test Library" }
             if (!($systemAppTestLibrary)) {
                 $testAppFile = Invoke-ScriptInBcContainer -containerName $containerName -scriptblock {


### PR DESCRIPTION
Issue #1417 Add parameters -databaseCredential and -compress to Backup-BcContainerDatabases
Issue #1416 Add parameter -sqlCredential to Run-TestsInBcContainer and Get-TestsFromBcContainer if using external SQL Server
Issue #1415 Implicitely import the Test Framework in Setup-BcContainerTestUsers if not already installed
Issue #1426 includePerformanceToolkit should automatically include includeTestToolkit and includeTestFrameWorkOnly (if not specified)
Publishing apps from a .zip file, where the name isn't .zip caused an error
Add parameter gitLab to Run-AlPipeline to add support for surfacing test errors on GitLab
