### PR TITLE
Fix inconsistency with documentation

### DIFF
--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -46,7 +46,7 @@ function New-BcImage {
     )
 
     if ($memory -eq "") {
-        $memory = "4G"
+        $memory = "8G"
     }
 
     $imageName = $imageName.ToLowerInvariant()


### PR DESCRIPTION
According to line 16, the default should be 8G. We ran into OutOfMemory issues when creating images with test libraries installed, so I think the documented behavior is better than the implemented one, so I would propose to change the implementation, not the documentation