### PR TITLE
dev

### DIFF
--- a/AppHandling/UnInstall-NavContainerApp.ps1
+++ b/AppHandling/UnInstall-NavContainerApp.ps1
@@ -43,13 +43,18 @@ function UnInstall-BcContainerApp {
         if ($appVersion) {
             $parameters += @{ "Version" = $appVersion }
         }
-        if ($doNotSaveData) {
-            $parameters += @{ "DoNotSaveData" = $true }
-        }
         if ($Force) {
             $parameters += @{ "Force" = $true }
         }
-        Uninstall-NavApp @parameters
+        if ($doNotSaveData) {
+            Uninstall-NavApp @parameters -doNotSaveData
+            Write-Host "Cleaning Schema from $appName on $tenant"
+            Sync-NAVApp $parameters -mode Clean
+        }
+        else {
+            Uninstall-NavApp @parameters
+        }
+
     } -ArgumentList $appName, $appVersion, $tenant, $doNotSaveData, $Force
     Write-Host -ForegroundColor Green "App successfully uninstalled"
 }

--- a/Bacpac/Backup-NavContainerDatabases.ps1
+++ b/Bacpac/Backup-NavContainerDatabases.ps1
@@ -90,18 +90,18 @@ function Backup-BcContainerDatabases {
             }
             Backup -ServerInstance $databaseServerInstance -database $DatabaseName -bakFolder $bakFolder -bakName "app" -databasecredential $databasecredential -compress:$compress
             $tenant | ForEach-Object {
-                if ($_ -eq "tenant") {
-                    $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance default -ErrorAction SilentlyContinue
-                    if ($tenantInfo) {
-                        $dbName = $tenantInfo.DatabaseName.replace('default','tenant')
-                    }
-                    else {
-                        $dbName = "tenant"
-                    }
+                $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance $_ -ErrorAction SilentlyContinue
+                if ($tenantInfo) {
+                    $dbName = $tenantInfo.DatabaseName
                 }
                 else {
-                    $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance $_
-                    $dbName = $tenantInfo.DatabaseName
+                    $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance default -ErrorAction SilentlyContinue
+                    if ($tenantInfo) {
+                        $dbName = $tenantInfo.DatabaseName.replace('default',$_)
+                    }
+                    else {
+                        $dbName = $_
+                    }
                 }
                 Backup -ServerInstance $databaseServerInstance -database $dbName -bakFolder $bakFolder -bakName $_ -databasecredential $databasecredential -compress:$compress
             }

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -31,7 +31,7 @@
  .Parameter AuthenticationEmail
   AuthenticationEmail of the admin user
  .Parameter memoryLimit
-  Memory limit for the container (default is unlimited for process isolation and 4G for hyperv isolation containers)
+  Memory limit for the container (default is unlimited for process isolation and 8G for hyperv isolation containers)
  .Parameter sqlMemoryLimit
   Memory limit for the SQL inside the container (default is no limit)
   Value can be specified as 50%, 1.5G, 1500M
@@ -1266,7 +1266,7 @@ function New-BcContainer {
                    )
 
     if ("$memoryLimit" -eq "" -and $isolation -eq "hyperv") {
-        $memoryLimit = "4G"
+        $memoryLimit = "8G"
     }
 
     $SqlServerMemoryLimit = 0

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,7 +2,10 @@
 Add parameter -features to Compile-AppInBcContainer to add support of the alc features parameter
 Add parameter -bakFile to Restore-BcDatabaseFromArtifacts to allow restoring custom database using the artifact binaries
 Issue #1426 performance test samples are installed before performance test toolkit
-Clean-BcContainerDatabase will now cleanup Schema and company when not saving data
+Clean-BcContainerDatabase will now cleanup Schema and company when -doNotSaveData is specified
+UnInstall-BcContainerApp will now cleanup Schema when -doNotSaveData is specified
+Regression: Backup-BcContainerDatabases couldn't backup the tenant template database when specified
+Setting default container memory size to 8Gb when using hyperv
 
 1.0.13
 Issue #1414 the magic setting defaultTenantHasAllowAppDatabaseWrite=Y is not used when using -cleandatabase or -newdatabase


### PR DESCRIPTION
UnInstall-BcContainerApp will now cleanup Schema when -doNotSaveData is specified
Regression: Backup-BcContainerDatabases couldn't backup the tenant template database when specified
Setting default container memory size to 8Gb when using hyperv