### PR TITLE
-multitenant + resillience in getallforms

### DIFF
--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -270,8 +270,15 @@ class ClientContext {
     }
     
     [ClientLogicalForm[]]GetAllForms() {
-        $forms = @()
-        $this.clientSession.OpenedForms.GetEnumerator() | ForEach-Object { $forms += $_ }
+        try {
+            $forms = @()
+            $this.clientSession.OpenedForms.GetEnumerator() | ForEach-Object { $forms += $_ }
+        }
+        catch {
+            Start-Sleep -Seconds 1
+            $forms = @()
+            $this.clientSession.OpenedForms.GetEnumerator() | ForEach-Object { $forms += $_ }
+        }
         return $forms
     }
     

--- a/AppHandling/Run-AlValidation.ps1
+++ b/AppHandling/Run-AlValidation.ps1
@@ -54,6 +54,8 @@
   Include this parameter to skip the connection test. If Connection Test fails in validation, Microsoft will execute manual validation.
  .Parameter useGenericImage
   Specify a private (or special) generic image to use for the Container OS.
+ .Parameter multitenant
+  Include this parameter to use a multitenant container for the validation tests. Default is to use single tenant as validation doesn't run tests.
  .Parameter DockerPull
   Override function parameter for docker pull
  .Parameter NewBcContainer
@@ -95,6 +97,7 @@ Param(
     [switch] $skipAppSourceCop,
     [switch] $skipConnectionTest,
     [string] $useGenericImage = (Get-BestGenericImageName),
+    [switch] $multitenant,
     [scriptblock] $DockerPull,
     [scriptblock] $NewBcContainer,
     [scriptblock] $CompileAppInBcContainer,
@@ -356,6 +359,7 @@ Measure-Command {
         "vsixFile" = $vsixFile
         "licenseFile" = $licenseFile
         "EnableTaskScheduler" = $true
+        "Multitenant" = $multitenant
         "AssignPremiumPlan" = $assignPremiumPlan
         "MemoryLimit" = $memoryLimit
     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,8 @@ Add mapCountryCode to $bcContainerHelperConfig
 Use mapCountryCode in Get-BcArtifactUrl to allow getting artifacts for countries which doesn't have own artifacts
 Use mapCountryCode in Run-AlValidation to allow running validation for all countries (max. 1 time per artifact)
 Issue #1536 Random running Test failure
+Run-AlValidation use single tenant containers by default for performance
+Add resilience to ClientContext::GetAllForms
 
 1.0.16
 Issue #1516 Sort-AppFoldersByDependencies can't handle twice the same app in the baseFolder


### PR DESCRIPTION
Run-AlValidation use single tenant containers by default for performance
Add resilience to ClientContext::GetAllForms
