### PR TITLE
Change Traefik docker image to use the official 1.7 release

### DIFF
--- a/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
+++ b/ContainerHandling/Setup-TraefikContainerForNavContainers.ps1
@@ -58,7 +58,7 @@ function Setup-TraefikContainerForBcContainers {
 
     Process {
         $traefikForBcBasePath = "c:\programdata\bccontainerhelper\traefikforbc"
-        $traefikDockerImage = "stefanscherer/traefik-windows:v1.7.12"
+        $traefikDockerImage = "traefik:v1.7-windowsservercore-1809"
         $traefiktomltemplate = (Join-Path $traefikForBcBasePath "config\template_traefik.toml")
         if ($forceHttpWithTraefik) {
             $traefikToml = (Join-Path $PSScriptRoot "traefik\template_traefik.toml")


### PR DESCRIPTION
The Traefik docker image was about 2 years old and from an unofficial and no longer updated source. Since then there have been 16 maintenance releases. By changing this to the current 1.7 Windows release from the official repo fixes such as minor tls and docker api updates will get automatically applied until support for the 1.7 version runs out. See all changes [here](https://github.com/traefik/traefik/blob/v1.7/CHANGELOG.md).

I have tested this out on a dev environment while trying to find an unrelated problem in our setup a month back and have seen no side effects to this change.

if a "latest"1.7 image is not wanted for fear of a future update breaking production environments, `traefik:v1.7.28-windowsservercore-1809` would also work.