### PR TITLE
Extending functions Export-ModifiedObjectsAsDeltas & Convert-Modified…

### DIFF
--- a/ObjectHandling/Convert-ModifiedObjectsToAl.ps1
+++ b/ObjectHandling/Convert-ModifiedObjectsToAl.ps1
@@ -51,7 +51,8 @@ function Convert-ModifiedObjectsToAl {
         [string] $alFilePattern = "*",
         [string] $dotNetAddInsPackage,
         [ScriptBlock] $alFileStructure,
-        [string] $runTxt2AlInContainer = $containerName
+        [string] $runTxt2AlInContainer = $containerName,
+        [string] $originalFolder = ""
     )
 
     AssumeNavContainer -containerOrImageName $containerName -functionName $MyInvocation.MyCommand.Name
@@ -80,7 +81,7 @@ function Convert-ModifiedObjectsToAl {
         if ($filter -eq "None") {
             $filter = "Modified=1"
         }
-        Export-ModifiedObjectsAsDeltas -containerName $containerName -sqlCredential $sqlCredential -useNewSyntax -filter $filter
+        Export-ModifiedObjectsAsDeltas -containerName $containerName -sqlCredential $sqlCredential -useNewSyntax -filter $filter -originalFolder $originalFolder
         $myDeltaFolder  = Join-Path $ExtensionsFolder "$containerName\delta$suffix"
     }
 

--- a/ObjectHandling/Export-ModifiedObjectsAsDeltas.ps1
+++ b/ObjectHandling/Export-ModifiedObjectsAsDeltas.ps1
@@ -35,7 +35,8 @@ function Export-ModifiedObjectsAsDeltas {
         [string] $filter = "Modified=1",
         [string] $deltaFolder = "",
         [string] $fullObjectsFolder = "",
-        [switch] $openFolder
+        [switch] $openFolder,
+        [string] $originalFolder = ""
     )
 
     AssumeNavContainer -containerOrImageName $containerName -functionName $MyInvocation.MyCommand.Name
@@ -52,9 +53,11 @@ function Export-ModifiedObjectsAsDeltas {
         $suffix = "-newsyntax"
         $exportTo = 'txt folder (new syntax)'
     }
-    $navversion = Get-NavContainerNavversion -containerOrImageName $containerName
-    $originalFolder   = Join-Path $ExtensionsFolder "Original-$navversion$suffix"
-
+    if (!$originalFolder) {
+      $navversion = Get-NavContainerNavversion -containerOrImageName $containerName
+      $originalFolder   = Join-Path $ExtensionsFolder "Original-$navversion$suffix"
+    }
+    
     if (!(Test-Path $originalFolder)) {
         throw "Folder $originalFolder must contain all Nav base objects (original). You can use Export-NavContainerObjects on a fresh container or create your development container using New-CSideDevContainer, which does this automatically."
     }


### PR DESCRIPTION
…ObjectsToAl with parameter -originalFolder

Adding additional parameter originalFolder to the functions  Export-ModifiedObjectsAsDeltas & Convert-ModifiedObjectsToAl.

Currently $originalFolder is looking at Extension folder based on container version. In scenarios when your container contains different application version from platform version it becomes a limitation. For e.g. our container is is running CU10, while base appication is CU5. Therefore, exposing  $originalFolder as parameter allows us to override it and specify our folder with origal files.