### PR TITLE
Support same previousapp

### DIFF
--- a/AppHandling/Run-AlCops.ps1
+++ b/AppHandling/Run-AlCops.ps1
@@ -152,12 +152,14 @@ function Run-AlCops {
                 }
                 if ($previousAppVersions.ContainsKey("$($appJson.Publisher)_$($appJson.Name)")) {
                     $previousVersion = $previousAppVersions."$($appJson.Publisher)_$($appJson.Name)"
-                    $appSourceCopJson += @{
-                        "Publisher" = $appJson.Publisher
-                        "Name" = $appJson.Name
-                        "Version" = $previousVersion
+                    if ($previousVersion -ne $appJson.Version) {
+                        $appSourceCopJson += @{
+                            "Publisher" = $appJson.Publisher
+                            "Name" = $appJson.Name
+                            "Version" = $previousVersion
+                        }
+                        Write-Host "Using previous app: $($appJson.Publisher)_$($appJson.Name)_$previousVersion.app"
                     }
-                    Write-Host "Using previous app: $($appJson.Publisher)_$($appJson.Name)_$previousVersion.app"
                 }
                 $appSourceCopJson | ConvertTo-Json -Depth 99 | Set-Content (Join-Path $tmpFolder "appSourceCop.json")
 

--- a/AppHandling/Run-AlValidation.ps1
+++ b/AppHandling/Run-AlValidation.ps1
@@ -569,7 +569,7 @@ try {
         Remove-Item $tmpFolder -Recurse -Force
     
         $installedApp = $installedApps | Where-Object { $_.Name -eq $appJson.Name -and $_.Publisher -eq $appJson.Publisher -and $_.AppId -eq $appJson.Id }
-        if ($installedApp.Version -eq $appJson.Version) {
+        if ($installedApp -ne $null -and $installedApp.Version -eq $appJson.Version) {
             Write-Host "Skipping installation of $($installedApp.Name) version $($installedApp.Version), version already installed."
         }
         else {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,8 @@ Issue #1706 App generation failed without info after fixing #1696
 Issue Cannot download symbols for apps with special characters
 Issue #1728 Get-BcContainerApp doesn't return the appFile
 Support that bcartifactsCacheFolder, containerHelperFolder and dvdPath can be a docker volume instead of a bind mount (for performance)
+Run-AlValidation doesn't fail getting the same app in apps and previousApps (if apps in the middle of the dependency chain hasn't changed)
+Run-AlCops doesn't use previousApp if it is the same version as the app
 
 2.0.5
 Issue #1668 Run-AlValidation fails if app filename has a comma (and there is only one app)


### PR DESCRIPTION
Run-AlValidation doesn't fail getting the same app in apps and previousApps (if apps in the middle of the dependency chain hasn't changed)
Run-AlCops doesn't use previousApp if it is the same version as the app
