### PR TITLE
Dev

### DIFF
--- a/AppHandling/Run-AlValidation.ps1
+++ b/AppHandling/Run-AlValidation.ps1
@@ -457,7 +457,7 @@ Measure-Command {
             "tenant" = $tenant
             "credential" = $credential
             "appFile" = $_
-            "skipVerification" = $skipVerification
+            "skipVerification" = $true
             "sync" = $true
             "install" = $true
         }
@@ -523,7 +523,7 @@ try {
             "tenant" = $tenant
             "credential" = $credential
             "appFile" = $_
-            "skipVerification" = $skipVerification
+            "skipVerification" = $true
             "sync" = $true
             "install" = $true
             "useDevEndpoint" = $false

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -748,6 +748,9 @@ function New-BcContainer {
     }
 
     if ($clickonce) {
+        if ($useTraefik) {
+            Write-Host "WARNING: ClickOnce doesn't work with traefik v1 (which is the one used in this version of ContainerHelper)"
+        }
         $parameters += "--env clickonce=Y"
     }
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -10,6 +10,7 @@ Issue #1829 Import-module fails with no good error when config file is bad or em
 Breaking change: Fix Install-BcAppFromAppSource to use new admin center API (remove old hack)
 Issue #1815 Page 810 Web Service takes very long to open
 Added parameter -network to New-BcContainer to select which docker network the container should use
+Issue #1833 Add warning if using ClickOnce and useTraefik
 
 2.0.7
 Support -bakFile and -replaceExternalDatabases together on New-BcContainer

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -11,6 +11,8 @@ Breaking change: Fix Install-BcAppFromAppSource to use new admin center API (rem
 Issue #1815 Page 810 Web Service takes very long to open
 Added parameter -network to New-BcContainer to select which docker network the container should use
 Issue #1833 Add warning if using ClickOnce and useTraefik
+Issue #1793 Setup-TraefikContainerForNavContainers | Use my own certificate | traefik.toml missing link to certificate
+Use SkipVerification on installApps and previousApps as the certificate on old apps might have expired
 
 2.0.7
 Support -bakFile and -replaceExternalDatabases together on New-BcContainer


### PR DESCRIPTION
Issue #1833 Add warning if using ClickOnce and useTraefik
Use SkipVerification on installApps and previousApps as the certificate on old apps might have expired
