### PR TITLE
Running Business Central in docker using remote SQL server

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1677,8 +1677,8 @@ if (-not `$restartingInstance) {
                     Write-Host "Using Shared Encryption Key file"
                     Copy-Item -Path $sharedEncryptionKeyFile -Destination $containerEncryptionKeyFile
                 }
-                else {
-                    New-Item -Path ([System.IO.Path]::GetDirectoryName($sharedEncryptionKeyFile)) -ItemType Directory | Out-Null
+                elseif((Test-Path ($sharedEncryptionKeyFile | Split-Path -Parent)) -eq $false) {
+                    New-Item -Path ($sharedEncryptionKeyFile | Split-Path -Parent) -ItemType Directory | Out-Null
                 }
             }
         }


### PR DESCRIPTION
Together with my colleague Theo Gosselink we've tried to use one of our dedicated SQL servers to host the BC database instead of a SQL Instance on the Docker host or inside the Docker container. 

We've used this blog post as starting point: https://freddysblog.com/2021/02/28/running-business-central-in-docker-using-sql-on-the-host/

We ran into the following issues: 
**Restore-BcDatabaseFromArtifacts**: Default the database backup file is downloaded on the machine where the script is running, usually the docker host. After downloading the artifacts the backup file path is passed into New-NAVDatabase. The SQL Instance cannot find the backup because it's a path to the local system on the docker host, e.g. 
   _"C:\bcartifacts.cache\sandbox\17.4.21491.23784\nl\BusinessCentral-NL.bak"_
   
We've resolved this by executing a file copy for the backup file from the docker host to the SQL server. An UNC path is created to the SQL Instance default backup folder. After the copy a new local path is created and passed into New-NAVDatabase, eg:
   _"C:\mssql\backup\BusinessCentral-NL.bak"_

**Note**: On the SQL Server file sharing should be enabled and the user executing the script on the docker host should've access on the backup folder of the SQL Instance.

**Remove-BcDatabase**: After dropping the database the database files where not removed. This functionality was only available if the database server is 'localhost'.

We've resolved this by implementing two methods for removing the files. If the database server is not localhost the paths to the database files are first converted to UNC paths before executing Remove-Item.

