### PR TITLE
Running multiple traefik containers using same external database

### DIFF
--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -219,6 +219,7 @@ Check-BcContainerHelperPermissions -Silent
 . (Join-Path $PSScriptRoot "ContainerHandling\Flush-ContainerHelperCache.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\Get-LatestAlLanguageExtensionUrl.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\Get-AlLanguageExtensionFromArtifacts.ps1")
+. (Join-Path $PSScriptRoot "ContainerHandling\traefik\Add-DomainToTraefikConfig.ps1")
 
 # Object Handling functions
 . (Join-Path $PSScriptRoot "ObjectHandling\Export-NavContainerObjects.ps1")

--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -69,6 +69,7 @@ function Get-ContainerHelperConfig {
                 "vn" = "w1"
                 "za" = "w1"
             }
+            "TraefikUseDnsNameAsHostName" = $false
         }
         $bcContainerHelperConfigFile = "C:\ProgramData\BcContainerHelper\BcContainerHelper.config.json"
         if (Test-Path $bcContainerHelperConfigFile) {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1,4 +1,4 @@
-﻿<# 
+<# 
  .Synopsis
   Create or refresh a NAV/BC Container
  .Description
@@ -1564,7 +1564,7 @@ if ($multitenant) {
         $dlRule="PathPrefixStrip:${dlPart}"
 
         $traefikHostname = $publicDnsName.Split(".")[0]
-        
+
         $traefikConfig = Get-Content
 
         $webPort = "443"

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -636,10 +636,6 @@ function New-BcContainer {
         if (-not $PublicDnsName) {
             throw "Using Traefik only makes sense if you allow external access, so you have to provide the public DNS name (param -PublicDnsName)"
         }
-        
-        Add-DomainToTraefikConfig `
-            -PublicDnsName $PublicDnsName `
-            -BcContainerHelperPath $bcContainerHelperConfig.containerHelperFolder
     }
 
     $parameters = @()

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1,4 +1,4 @@
-<# 
+﻿<# 
  .Synopsis
   Create or refresh a NAV/BC Container
  .Description
@@ -1574,8 +1574,7 @@ if ($multitenant) {
             $traefikProtocol = "http"
         }
 
-        $additionalParameters += @("--hostname $traefikHostname",
-                                   "-e webserverinstance=$containerName",
+        $additionalParameters += @("-e webserverinstance=$containerName",
                                    "-e publicdnsname=$publicDnsName", 
                                    "-l `"traefik.protocol=$traefikProtocol`"",
                                    "-l `"traefik.web.frontend.rule=$webclientRule`"", 

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -636,6 +636,10 @@ function New-BcContainer {
         if (-not $PublicDnsName) {
             throw "Using Traefik only makes sense if you allow external access, so you have to provide the public DNS name (param -PublicDnsName)"
         }
+        
+        Add-DomainToTraefikConfig `
+            -PublicDnsName $PublicDnsName `
+            -BcContainerHelperPath $bcContainerHelperConfig.containerHelperFolder
     }
 
     $parameters = @()
@@ -1560,6 +1564,8 @@ if ($multitenant) {
         $dlRule="PathPrefixStrip:${dlPart}"
 
         $traefikHostname = $publicDnsName.Split(".")[0]
+        
+        $traefikConfig = Get-Content
 
         $webPort = "443"
         if ($forceHttpWithTraefik) {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1565,8 +1565,6 @@ if ($multitenant) {
 
         $traefikHostname = $publicDnsName.Split(".")[0]
 
-        $traefikConfig = Get-Content
-
         $webPort = "443"
         if ($forceHttpWithTraefik) {
             $webPort = "80"

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1563,8 +1563,6 @@ if ($multitenant) {
         $snapRule="PathPrefix:${snapPart};ReplacePathRegex: ^${snapPart}(.*) /$ServerInstance`$1"
         $dlRule="PathPrefixStrip:${dlPart}"
 
-        $traefikHostname = $publicDnsName.Split(".")[0]
-
         $webPort = "443"
         if ($forceHttpWithTraefik) {
             $webPort = "80"
@@ -1572,6 +1570,11 @@ if ($multitenant) {
         $traefikProtocol = "https"
         if ($forceHttpWithTraefik) {
             $traefikProtocol = "http"
+        }
+
+        if ($bcContainerHelperConfig.TraefikUseDnsNameAsHostName) {
+            $traefikHostname = $publicDnsName.Split(".")[0]
+            $additionalParameters += @("--hostname $traefikHostname")
         }
 
         $additionalParameters += @("-e webserverinstance=$containerName",

--- a/ContainerHandling/traefik/Add-DomainToTraefikConfig.ps1
+++ b/ContainerHandling/traefik/Add-DomainToTraefikConfig.ps1
@@ -6,22 +6,17 @@
   If public dns name does not exist it will be extended as a subdomain configuration (sans).
  .Parameter PublicDnsName
   Specifies the public dns name to add in traefik configuration.
- .Parameter BcContainerHelperPath
-  Specifies the path to BcContainerHelper. Usally this is 'C:\ProgramData\BcContainerHelper' (optional)
- .Example
-  Add-DomainToTraefikConfig -PublicDnsName "businesscentral.dynamics.com" -BcContainerHelperPath "C:\ProgramData\NavContainerHelper"
  .Example
   Add-DomainToTraefikConfig -PublicDnsName "businesscentral.dynamics.com" 
 #>
 function Add-DomainToTraefikConfig {
     Param (
-        [string]$PublicDnsName,
-        [string]$BcContainerHelperPath = "C:\ProgramData\BcContainerHelper"
+        [string]$PublicDnsName
     )
 
     Write-Host "Looking up for dns Name '$PublicDnsName' in Traefik configuration . . ."
 
-    $tomlFile = (Join-Path -Path $BcContainerHelperPath -ChildPath "traefikforbc\config\traefik.toml")
+    $tomlFile = (Join-Path -Path $hostHelperFolder -ChildPath "traefikforbc\config\traefik.toml")
     if (-not (Test-Path -Path $tomlFile)) {
         throw "Traefik configuration could not been found! Please call Setup-TraefikContainerForBcContainers before using -useTraefik"
     }

--- a/ContainerHandling/traefik/Add-DomainToTraefikConfig.ps1
+++ b/ContainerHandling/traefik/Add-DomainToTraefikConfig.ps1
@@ -1,0 +1,89 @@
+<# 
+ .Synopsis
+  Add public dns name to traefik configuration.
+ .Description
+  Check traefik.toml configuration file whether the given public dns name exists or not. 
+  If public dns name does not exist it will be extended as a subdomain configuration (sans).
+ .Parameter PublicDnsName
+  Specifies the public dns name to add in traefik configuration.
+ .Parameter BcContainerHelperPath
+  Specifies the path to BcContainerHelper. Usally this is 'C:\ProgramData\BcContainerHelper' (optional)
+ .Example
+  Add-DomainToTraefikConfig -PublicDnsName "businesscentral.dynamics.com" -BcContainerHelperPath "C:\ProgramData\NavContainerHelper"
+ .Example
+  Add-DomainToTraefikConfig -PublicDnsName "businesscentral.dynamics.com" 
+#>
+function Add-DomainToTraefikConfig {
+    Param (
+        [string]$PublicDnsName,
+        [string]$BcContainerHelperPath = "C:\ProgramData\BcContainerHelper"
+    )
+
+    Write-Host "Looking up for dns Name '$PublicDnsName' in Traefik configuration . . ."
+
+    $tomlFile = (Join-Path -Path $BcContainerHelperPath -ChildPath "traefikforbc\config\traefik.toml")
+    if (-not (Test-Path -Path $tomlFile)) {
+        throw "Traefik configuration could not been found! Please call Setup-TraefikContainerForBcContainers before using -useTraefik"
+    }
+    
+    Write-Host "Reading configuration from '$tomlFile'"
+    $traefikConfig = Get-Content $tomlFile
+    $newTraefikConfig = ""
+    $acmeDomainCfg = $false
+
+    foreach ($traefikConfigLine in $traefikConfig) {
+        $isAcmeDomainArea = (($traefikConfigLine -match "\[\[acme\.domains\]\]") -or ($traefikConfigLine -match "...main.?=.?") -or ($traefikConfigLine -match "...sans.?=.?\["))
+        if ($isAcmeDomainArea) {
+            $acmeDomainCfg = $true
+        }
+        if ($isAcmeDomainArea) {
+            switch ($true) {
+                ($traefikConfigLine -match "\[\[acme\.domains\]\]") {
+                    $newTraefikConfig += "$traefikConfigLine`n"
+                }
+                # domain configuration
+                ($traefikConfigLine -match "...main.?=.?(.*)") {
+                    $newTraefikConfig += "$traefikConfigLine`n"
+                    if ($Matches[1] -match $PublicDnsName) {
+                        Write-Host "DNS name '$PublicDnsName' has been found in Traefik configuration."
+                        return
+                    }
+                }
+                # subdomain configuration
+                ($traefikConfigLine -match "...sans.?=.?\[(.*)]") { 
+                    if ($Matches[1] -match $PublicDnsName) {
+                        Write-Host "DNS name '$PublicDnsName' has been found in Traefik configuration (subdomain)."
+                        return
+                    }
+                    # if domain has not been found in subdomain configuration (sans) add requested domain to list
+                    $sansConfiguration = $('"' + $PublicDnsName + '"')
+                    foreach ($subdomain in $Matches[1].Split(',')) {
+                        if ($sansConfiguration -ne "") {
+                            $sansConfiguration += ","
+                        }
+                        $sansConfiguration += $subdomain
+                    } 
+                    $newTraefikConfig += "   sans = [$sansConfiguration]`n"
+
+                    $acmeDomainCfg = $false
+                    Write-Host "DNS name '$PublicDnsName' has been added to Traefik configuration as subdomain."
+                }
+            }
+        } else {
+            # if acme domain configuration has found, but requested domain does not add "sans" configuration to yaml
+            if ($acmeDomainCfg -eq $true) {
+                $newTraefikConfig += $('   sans = ["' + $PublicDnsName + '"]')
+                $newTraefikConfig += "`n"
+
+                $acmeDomainCfg = $false
+                Write-Host "DNS name '$PublicDnsName' has been added to Traefik configuration as subdomain."
+            }
+            $newTraefikConfig += "$traefikConfigLine`n"
+        }
+    }
+
+    Write-Host "Updating configuration in '$tomlFile'"
+    Set-Content -Path $tomlFile -Value $newTraefikConfig
+
+    Write-Host "Please restart traefik container to apply changes in configuration. Otherwise you may face certificate related error messages." -ForegroundColor Yellow
+}


### PR DESCRIPTION
As described in issue #1867 when creating mutliple traefik containers using the same public dns name (e.g. `bc.domain.com`) all containers will get the first part of the public dns name as hostname (e.g. `bc`). This leads to HealthCheck issues and the server instances are battling against each other. The result of this is that a user get kicked out really fast (after a few seconds of inactivity). It also seems to make the complete environment extremely slow.

The problem can be solved by two ways:

1. Create subdomains for each container so every container will get a unique hostname
2. Remove the link in between public dns name and hostname

Option 1 is leading to another problem. With `Setup-TraefikContainerForBcContainers` you specify _**one**_ public dns name for which the acme challenge (*Lets Encrypt*) will be performed. If you now create a new subdomain with a different public dns name , for example `bc.domain.com` & `bc-test.domain.com`, you will not get a valid certificate for `bc-test.domain.com` and Browser, VSCode, Business Central App will complain about it.
For this I've added the command `Add-DomaintToTraefikConfig`. This command is included in `New-BcContainer` and checks the `traefik.toml` file for the acme challenge domains. If not already present as main domain or subdomain the public dns name will be added automatically.

> **Note**<br>As far as I noticed it is necessary to restart the traefik container after changing `traefik.toml` to retrieve the certificate. `Add-DomaintToTraefikConfig` is telling the user to do this after the container has been created manually. It's just `docker restart <traefik container name>`.

In #1867 @tfenster mentioned that the reason for syncing container hostname and public dns name was that "Web Client or/and NST" are not working correctly. I've tested the following scenarios after removing this:

- Web Client with Edge & Chrome **[OK]**
- Mobile Business Central App (Android) **[OK]**
- Windows Business Central App **[OK]**
- API Call using Postman **[OK]**

I cannot find any weird behavior after this. Anyway, as mentioned in #1867, I added configuration setting `TraefikUseDnsNameAsHostName` (default: false) to `bcContainerHelperConfig`. This is restoring the original behavior.
