### PR TITLE
Fix issue with parsing version information for alpha versions of 7-Zip

### DIFF
--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -240,7 +240,7 @@ function Expand-7zipArchive {
     $use7zip = $false
     if ((Get-ContainerHelperConfig).use7zipIfAvailable -and (Test-Path -Path $7zipPath -PathType Leaf)) {
         try {
-            $use7zip = [decimal]::Parse([System.Diagnostics.FileVersionInfo]::GetVersionInfo($7zipPath).FileVersion, [System.Globalization.CultureInfo]::InvariantCulture) -ge 19
+            $use7zip = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($7zipPath).FileMajorPart -ge 19
         }
         catch {
             $use7zip = $false


### PR DESCRIPTION
Fix an **Expand-7zipArchive** helper function issue with parsing 7-Zip version information.
Tested with 7-Zip version: **"21.01 alpha"**.

This pull request is for this issue: #1913
