### PR TITLE
Added minimum version for generatecrossreferences

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -489,7 +489,7 @@ function Compile-AppInBcContainer {
             $alcParameters += @("/nowarn:$nowarn")
         }
 
-        if ($GenerateCrossReferences) {
+        if ($GenerateCrossReferences -and $platformversion.Major -ge 18) {
             $alcParameters += @("/generatecrossreferences")
         }
 


### PR DESCRIPTION
The new `generatecrossreferences ` flag is only supported by alc-compilers in BC18 and newer.
Older compilers will fail if the parameter is supplied.