### PR TITLE
Support applicationInsightsConnectionString in app.json

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1030,24 +1030,39 @@ Write-Host -ForegroundColor Yellow @'
     }
     catch {}
 
-    if ($app -and $applicationInsightsKey) {
-        if ($appJson.psobject.Properties.name -eq "applicationInsightskey") {
-            $appJson.applicationInsightsKey = $applicationInsightsKey
+    $bcVersion = [System.Version]$artifactUrl.Split('/')[4]
+    if($app) {
+        if(($appJson.runtime -ge 7.2) -or (!$appJson.runtime -and $bcVersion -ge [System.Version]"18.2")) {
+            if($applicationInsightsConnectionString) {
+                if ($appJson.psobject.Properties.name -eq "applicationInsightsConnectionString") {
+                $appJson.applicationInsightsConnectionString = $applicationInsightsConnectionString
+                }
+                else {
+                    Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsConnectionString" -Value $applicationInsightsConnectionString
+                }
+                $appJsonChanges = $true
+            }
+            else if($applicationInsightsKey) {
+                if ($appJson.psobject.Properties.name -eq "applicationInsightskey") {
+                    $appJson.applicationInsightsKey = $applicationInsightsKey
+                }
+                else {
+                    Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsKey" -Value $applicationInsightsKey
+                }
+                $appJsonChanges = $true
+            }
         }
         else {
-            Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsKey" -Value $applicationInsightsKey
+            if($applicationInsightsKey) {
+                if ($appJson.psobject.Properties.name -eq "applicationInsightskey") {
+                    $appJson.applicationInsightsKey = $applicationInsightsKey
+                }
+                else {
+                    Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsKey" -Value $applicationInsightsKey
+                }
+                $appJsonChanges = $true
+            }
         }
-        $appJsonChanges = $true
-    }
-    
-    if ($app -and $applicationInsightsConnectionString) {
-        if ($appJson.psobject.Properties.name -eq "applicationInsightsConnectionString") {
-            $appJson.applicationInsightsConnectionString = $applicationInsightsConnectionString
-        }
-        else {
-            Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsConnectionString" -Value $applicationInsightsConnectionString
-        }
-        $appJsonChanges = $true
     }
 
     if ($appJsonChanges) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1664,3 +1664,4 @@ finally {
 }
 }
 Export-ModuleMember -Function Run-AlPipeline
+

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -48,6 +48,8 @@
   Revision number for build. Will be stamped into the revision part of the app.json version number property.
  .Parameter applicationInsightsKey
   ApplicationInsightsKey to be stamped into app.json for all apps
+ .Parameter applicationInsightsConnectionString
+  ApplicationInsightsConnectionString to be stamped into app.json for all apps
  .Parameter testResultsFile
   Filename in which you want the test results to be written. Default is TestResults.xml, meaning that test results will be written to this filename in the base folder. This parameter is ignored if doNotRunTests is included.
  .Parameter testResultsFormat
@@ -176,6 +178,7 @@ Param(
     [int] $appBuild = 0,
     [int] $appRevision = 0,
     [string] $applicationInsightsKey,
+    [string] $applicationInsightsConnectionString,
     [string] $testResultsFile = "TestResults.xml",
     [Parameter(Mandatory=$false)]
     [ValidateSet('XUnit','JUnit')]
@@ -1036,6 +1039,16 @@ Write-Host -ForegroundColor Yellow @'
         }
         $appJsonChanges = $true
     }
+    
+    if ($app -and $applicationInsightsConnectionString) {
+        if ($appJson.psobject.Properties.name -eq "applicationInsightsConnectionString") {
+            $appJson.applicationInsightsConnectionString = $applicationInsightsConnectionString
+        }
+        else {
+            Add-Member -InputObject $appJson -MemberType NoteProperty -Name "applicationInsightsConnectionString" -Value $applicationInsightsConnectionString
+        }
+        $appJsonChanges = $true
+    }
 
     if ($appJsonChanges) {
         $appJson | ConvertTo-Json -Depth 99 | Set-Content $appJsonFile
@@ -1651,4 +1664,3 @@ finally {
 }
 }
 Export-ModuleMember -Function Run-AlPipeline
-


### PR DESCRIPTION
Per runtime version 7.2 applicationInsightsKey is being deprecated by Microsoft (see link below). This change supports the replacement: **applicationInsightsConnectionString**

Microsoft Link: [https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-json-files](https://docs.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/devenv-json-files)