### PR TITLE
Add ukraine to w1 mapping

### DIFF
--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -81,6 +81,7 @@ function Get-ContainerHelperConfig {
                 "th" = "w1"
                 "tn" = "w1"
                 "tw" = "w1"
+                "ua" = "w1"
                 "vn" = "w1"
                 "za" = "w1"
             }


### PR DESCRIPTION
As Ukraine localization is developed by partners and is w1-based, it is necessary to add this mapping to run Run-ALValidation.

(Rest of changes seems to be due to mixed line endings.)

#2029 