### PR TITLE
fix multitenant unpublish

### DIFF
--- a/AppHandling/UnPublish-NavContainerApp.ps1
+++ b/AppHandling/UnPublish-NavContainerApp.ps1
@@ -79,7 +79,13 @@ try {
             $params += @{ 'Version' = $version }
         }
         $appInfo = (Get-NAVAppInfo -ServerInstance $ServerInstance -Name $name @params)
-        if ([bool]($appInfo.Scope -contains 'Tenant')) {
+        $tenantScope = $false
+        Get-NAVAppInfo -ServerInstance $ServerInstance -Name $name @params | ForEach-Object {
+            if ([bool]($_.PSObject.Properties.Name -eq 'Scope')) {
+                if ($_.Scope -eq "Tenant") { $tenantScope = $true }
+            }
+        }
+        if ($tenantScope) {
             $params += @{ 'Tenant' = $tenant }
         }
 

--- a/AppHandling/UnPublish-NavContainerApp.ps1
+++ b/AppHandling/UnPublish-NavContainerApp.ps1
@@ -78,7 +78,6 @@ try {
         if ($version) {
             $params += @{ 'Version' = $version }
         }
-        $appInfo = (Get-NAVAppInfo -ServerInstance $ServerInstance -Name $name @params)
         $tenantScope = $false
         Get-NAVAppInfo -ServerInstance $ServerInstance -Name $name @params | ForEach-Object {
             if ([bool]($_.PSObject.Properties.Name -eq 'Scope')) {

--- a/AppHandling/UnPublish-NavContainerApp.ps1
+++ b/AppHandling/UnPublish-NavContainerApp.ps1
@@ -79,10 +79,8 @@ try {
             $params += @{ 'Version' = $version }
         }
         $appInfo = (Get-NAVAppInfo -ServerInstance $ServerInstance -Name $name @params)
-        if ([bool]($appInfo.PSObject.Properties.Name -eq 'Scope')) {
-            if ($appInfo.Scope -eq "Tenant") {
-                $params += @{ 'Tenant' = $tenant }
-            }
+        if ([bool]($appInfo.Scope -contains 'Tenant')) {
+            $params += @{ 'Tenant' = $tenant }
         }
 
         Write-Host "Unpublishing $name"


### PR DESCRIPTION
When an app exists in the with the same version in multiple tenants it's impossible to unpublish with the bccontainerhelper.

The condition here doesn't work when a list is returned by Get-NAVAppInfo.

I'm not sure if there is a better way to test if 'scope' exists in the list but I also can't see a scenario where the property doesn't exist.