### PR TITLE
Improve Upgrade Handling while publishing an App

### DIFF
--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -18,6 +18,8 @@
   Specify Add, Clean or Development based on how you want to synchronize the database schema. Default is Add
  .Parameter install
   Include this parameter if you want to install the app after publishing
+ .Parameter upgrade
+  Include this parameter if you want to upgrade the app after publishing. if no upgrade is necessary then its just installed instead.
  .Parameter tenant
   If you specify the install switch, then you can specify the tenant in which you want to install the app
  .Parameter packageType
@@ -319,7 +321,13 @@ try {
                             Sync-NavTenant -ServerInstance $ServerInstance -Tenant $tenant -Force
                             Sync-NavApp -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant @syncArgs -force -WarningAction Ignore
                         }
-                
+
+                        $navAppInfoFromDb = Get-NAVAppInfo -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant -TenantSpecificProperties
+                        if($navAppInfoFromDb.ExtensionDataVersion -eq  $navAppInfoFromDb.Version -and $upgrade){
+                            $install = $true
+                            $upgrade = $false
+                        }
+                        
                         if ($install) {
         
                             $languageArgs = @{}

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -322,10 +322,11 @@ try {
                             Sync-NavApp -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant @syncArgs -force -WarningAction Ignore
                         }
 
-                        $navAppInfoFromDb = Get-NAVAppInfo -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant -TenantSpecificProperties
-                        if($navAppInfoFromDb.ExtensionDataVersion -eq  $navAppInfoFromDb.Version -and $upgrade -and $install){
-                            $install = $true
-                            $upgrade = $false
+                        if($upgrade -and $install){
+                            $navAppInfoFromDb = Get-NAVAppInfo -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant -TenantSpecificProperties
+                            if($navAppInfoFromDb.ExtensionDataVersion -eq  $navAppInfoFromDb.Version){
+                                $upgrade = $false
+                            }
                         }
                         
                         if ($install) {

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -323,7 +323,7 @@ try {
                         }
 
                         $navAppInfoFromDb = Get-NAVAppInfo -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant $tenant -TenantSpecificProperties
-                        if($navAppInfoFromDb.ExtensionDataVersion -eq  $navAppInfoFromDb.Version -and $upgrade){
+                        if($navAppInfoFromDb.ExtensionDataVersion -eq  $navAppInfoFromDb.Version -and $upgrade -and $install){
                             $install = $true
                             $upgrade = $false
                         }


### PR DESCRIPTION
Add Documentation for upgrade parameter.
If upgrade is not needed just install the app. this helps when the user just wants to have the app running but doesn't know if an upgrade is necessary or not. just always publish with the upgrade parameter and then the app is ready in any case.