### PR TITLE
Add the ability to resolve runtime apps instead of apps

### DIFF
--- a/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
+++ b/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
@@ -115,9 +115,6 @@ function Resolve-DependenciesFromAzureFeed {
 
                                 $hasDependencyApp = $dependencyApp.Count -gt 0
                                 $hasDependencyRuntimeApp = $dependencyRuntimeApp.Count -gt 0
-                                Write-Host $runtimePackages
-                                Write-Host $hasDependencyApp
-                                Write-Host $hasDependencyRuntimeApp
                                 if ($hasDependencyApp -or $hasDependencyRuntimeApp) {
                                     if($hasDependencyRuntimeApp -and ($runtimePackages -or (-not $hasDependencyApp))) {
                                         $dep = $dependencyRuntimeApp[0]


### PR DESCRIPTION
This adds the ability to resolve runtime apps instead fo apps. This is need when apps should be installed without access to the developer license.