### PR TITLE
Remove-NAVServerUser fix while Invoking CodeUnits

### DIFF
--- a/ObjectHandling/Invoke-NavContainerCodeunit.ps1
+++ b/ObjectHandling/Invoke-NavContainerCodeunit.ps1
@@ -54,7 +54,9 @@ try {
             Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Enabled
         }
     
-        Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -Company $CompanyName -Force
+        if ($CompanyName) {
+            Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -Company $CompanyName -Force
+        }
 
         $Params = @{}
         if ($CompanyName) {

--- a/ObjectHandling/Invoke-NavContainerCodeunit.ps1
+++ b/ObjectHandling/Invoke-NavContainerCodeunit.ps1
@@ -69,11 +69,7 @@ try {
         }
         Invoke-NAVCodeunit -ServerInstance $ServerInstance -Tenant $tenant @Params -CodeunitId $CodeUnitId
     
-        if (!($userexist)) {
-            Remove-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -Force
-        } elseif ($userexist.state -eq "Disabled") {
-            Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Disabled
-        }
+        Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Disabled
 
     } -ArgumentList $tenant, $CompanyName, $Codeunitid, $MethodName, $Argument, $TimeZone
 }

--- a/ObjectHandling/Invoke-NavContainerCodeunit.ps1
+++ b/ObjectHandling/Invoke-NavContainerCodeunit.ps1
@@ -53,6 +53,8 @@ try {
         } elseif ($userexist.state -eq "Disabled") {
             Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Enabled
         }
+    
+        Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -Company $CompanyName -Force
 
         $Params = @{}
         if ($CompanyName) {
@@ -69,7 +71,7 @@ try {
         }
         Invoke-NAVCodeunit -ServerInstance $ServerInstance -Tenant $tenant @Params -CodeunitId $CodeUnitId
     
-        Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Disabled
+        Set-NAVServerUser -ServerInstance $ServerInstance -Tenant $tenant -WindowsAccount $me -state Disabled -Force
 
     } -ArgumentList $tenant, $CompanyName, $Codeunitid, $MethodName, $Argument, $TimeZone
 }


### PR DESCRIPTION
Hi Freddy,

With BC19 release, Invoke-NavContainerCodeunit.ps1 is now throwing an error on Line#73 (Remove-NAVServerUser).

I am not sure why do we need to remove the `user manager\containeradministrator` user in the first place. We can just choose to keep the user and disable it when it's not needed.

With this PR, I am eliminating the Remove-NAVSeverUser command altogether while fixing the Set-NAVServerUser at the end of CodeUnit execution.

Also, before the CodeUnit execution starts, I am setting the user's company as passed in parameters, just in case it's significant.

**Error in BC19:**
```
WARNING: Import Successful
You must choose a company before you can access the "User Login" table.
at <ScriptBlock>, <No file>: line 28
at Invoke-ScriptInBcContainer, C:\Program Files\WindowsPowerShell\Modules\BcContainerHelper\2.0.16\ContainerHandling\Invoke-ScriptInNavContainer.ps1: line 44
at Invoke-NavContainerCodeunit, C:\Program Files\WindowsPowerShell\Modules\BcContainerHelper\2.0.16\ObjectHandling\Invoke-NavContainerCodeunit.ps1: line 46
at global:Install-DemoDataPack, C:\Users\azure-admin\Desktop\SCRIPTS\SIMPMgmt.ps1: line 2810
at <ScriptBlock>, C:\Users\azure-admin\Desktop\SCRIPTS\Makefiles\SIP Makefiles\demo.inecta.com\SIPS\Make-TC.ps1: line 28
at <ScriptBlock>, <No file>: line 1
You must choose a company before you can access the "User Login" table.
At C:\Program Files\WindowsPowerShell\Modules\BcContainerHelper\2.0.16\ContainerHandling\Invoke-ScriptInNavContainer.ps1:45 char:13
+             throw $_.Exception.Message
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : OperationStopped: (You must choose...r Login" table.:String) [], RuntimeException
    + FullyQualifiedErrorId : You must choose a company before you can access the "User Login" table. 
```

**Warning in BC18:**
```
WARNING: Import Successful
WARNING: The user 'user manager\containeradministrator' cannot be removed because the user has been logged on to the system. Instead the user has been disabled.
```