### PR TITLE
Update Remove-NavContainerSession.ps1

### DIFF
--- a/ContainerHandling/Remove-NavContainerSession.ps1
+++ b/ContainerHandling/Remove-NavContainerSession.ps1
@@ -17,12 +17,10 @@ function Remove-BcContainerSession {
     )
 
     Process {
-        $containerId = Get-BcContainerId -containerName $containerName
-
-        if ($sessions.ContainsKey($containerId)) {
-            $session = $sessions[$containerId]
+        if ($sessions.ContainsKey($containerName)) {
+            $session = $sessions[$containerName]
             Remove-PSSession -Session $session
-            $sessions.Remove($containerId)
+            $sessions.Remove($containerName)
         }
     }
 }


### PR DESCRIPTION
Currently, sessions will not be evicted correctly as sessions collection using 'containerName' as a reference in [Get-NavContainerSession.ps1](https://github.com/microsoft/navcontainerhelper/blob/master/ContainerHandling/Get-NavContainerSession.ps1). This small fix will use 'containerName' as a reference to remove sessions from sessions collection. 