### PR TITLE
Preserve special characters in app.json

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1228,7 +1228,8 @@ Write-Host -ForegroundColor Yellow @'
     }
 
     if ($appJsonChanges) {
-        $appJson | ConvertTo-Json -Depth 99 | Set-Content $appJsonFile
+        $appJsonContent = $appJson | ConvertTo-Json -Depth 99 
+        [System.IO.File]::WriteAllLines($appJsonFile, $appJsonContent)
     }
 
     if ($useDevEndpoint) {


### PR DESCRIPTION
Right now this causes Umlauts to be converted into something else:

Before:
```
"dependencies": [
    {
      "id": "c326380d-26f9-4e5c-aaf5-e166de5538db",
      "name": "AppName",
      "publisher": "publisher ö",
      "version": "18.1.5.0"
    }
  ],
```

After:
```
"dependencies": [
    {
      "id": "c326380d-26f9-4e5c-aaf5-e166de5538db",
      "name": "AppName",
      "publisher": "publisher �",
      "version": "18.1.5.0"
    }
  ],
```

When compiling the app, the dependency can't be found, because the publisher doesn't match.

