### PR TITLE
Fix ignore disabled Tests

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1739,7 +1739,7 @@ $testAppIds.Keys | ForEach-Object {
         Get-ChildItem -Path $folder -Filter "disabledTests.json" -Recurse | ForEach-Object {
             $disabledTestsStr = Get-Content $_.FullName -Raw
             Write-Host "Disabled Tests:`n$disabledTestsStr"
-            $disabledTests += @($disabledTestsStr | ConvertFrom-Json)
+            $disabledTests += ($disabledTestsStr | ConvertFrom-Json)
         }
     }
     $Parameters = @{


### PR DESCRIPTION
In the old implementation, files with more than one disabled test would be converted to an array of array. 

disabledTests.json:
```json
[
    {
        "codeunitName":  "lbt TestSales",
        "method":  "Sales_Test_GlEntry"
    },
    {
        "codeunitName":  "lbt TestSales",
        "method":  "Sales_Test_GlEntry"
    }
]
```
Result (converted back to json for readability):
```powershell
PS C:\WINDOWS\system32> $disabledTests | ConvertTo-Json
{
    "value":  [
                  {
                      "codeunitName":  "lbt TestSales",
                      "method":  "Sales_Test_GlEntry"
                  },
                  {
                      "codeunitName":  "lbt TestSales",
                      "method":  "CreateProdOrderfromSales"
                  }
              ],
    "Count":  2
}
```

This would break the skipping of tests i.e. the test would still be run.
```powershell
PS C:\WINDOWS\system32> Run-TestsInBcContainer runtest3 -credential $credential -extensionId "b5e0ac27-63f0-47e7-83c8-0bbfac2d3cb7" -disabledTests $disabledTests
WARNING: TaskScheduler is running in the container, this can lead to test failures. Specify -EnableTaskScheduler:$false to disable Task Scheduler.
Connecting to http://localhost:80/BC/cs?tenant=default
  Codeunit 50100 lbt TestSales Failure (1.593 seconds)
    Testfunction Sales_Test_GlEntry Failure (0 seconds)
    Testfunction CreateProdOrderfromSales Failure (0.124 seconds)
  Codeunit 50101 lbt Test Purchase Success (0.263 seconds)
```