### PR TITLE
Fix problems with AAD authentication against dev endpoint

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1475,7 +1475,7 @@ try {
     }
 
     if ($AadAppId) {
-        $customNavSettings += @("ValidAudiences=$AadAppId", "DisableTokenSigningCertificateValidation=True", "ExtendedSecurityTokenLifetime=24", "ClientServicesCredentialType=NavUserPassword")
+        $customNavSettings += @("ValidAudiences=$AadAppId;https://api.businesscentral.dynamics.com", "DisableTokenSigningCertificateValidation=True", "ExtendedSecurityTokenLifetime=24", "ClientServicesCredentialType=NavUserPassword")
     }
 
     if ($AadTenant) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -12,6 +12,7 @@ Issue #2259 - FilesOnly containers doesn't respect the -vsixFile parameter
 Better AAD support for containers
 Add AadTenant, AadAppIdUri and AadAppId to New-BcContainer for enhanced AAD support
 Issue #2267 Publish-BcContainerApp as Delegated Admin doesn't work
+Add standard audience as valid to support the current implementation in the AL extension when calling the dev endpoint with ADD auth
 
 3.0.0
 Enable Telemetry. BcContainerHelper will emit usage statistics telemetry to Microsoft for all commands used.


### PR DESCRIPTION
Based on https://www.yammer.com/dynamicsnavdev/#/Threads/show?threadId=1496929793343488, I tried to implement AAD authentication for dev usage. With the help of @kalberes and @SBalslev I could get it up and running, but the VS Code AL extension creates a bearer token with audience https://api.businesscentral.dynamics.com when e.g. downloading symbols. Therefore, we need to add that to the valid audiences as well. If and when that behavior is changed, we could remove it again. Setting it via customNavSettings unfortunately doesn't work as those are first evaluated and then [this](https://github.com/microsoft/navcontainerhelper/blob/26de82557f34c5e1fab8568312c235b390b2a89f/ContainerHandling/New-NavContainer.ps1#L1478) overrides them. On startup it looks like this:

```
PS [sshhost]:C:\Users\vmadmin> New-BcContainer `
>>     -containerName $containerName `
>>     -accept_eula `
>>     -artifact $artifactUrl `
>>     -auth AAD `
>>     -Credential $credential `
>>     -imageName "mybc" `
>>     -authenticationEMail $AadUserName `
>>     -additionalParameters @("--env CustomNavSettings=ValidAudiences=$($AdProperties.SsoAdAppId);https://api.businesscentral.dynamics.com")  `
>>     -PublicDnsName $publicDns `
>>     -PublishPorts 80,7049 `
>>     -AadTenant "$($AadUserName.Split('@')[1])" `
>>     -AadAppId "$($AdProperties.SsoAdAppId)" `
>>     -AadAppIdUri $appIdUri `
>>     -multitenant:$false

BcContainerHelper is version 3.0.1-preview536
BcContainerHelper is running as administrator
Host is Microsoft Windows Server 2022 Datacenter Azure Edition - ltsc2022
Docker Client Version is 20.10.12
Docker Server Version is 20.10.12
...
Modifying Service Tier Config File with Instance Specific Settings
Modifying Service Tier Config File with settings from environment variable
Setting ValidAudiences to 2a1d851f-b0a2-497a-96ca-0154a5195c52;https://api.businesscentral.dynamics.com
Setting ValidAudiences to 2a1d851f-b0a2-497a-96ca-0154a5195c52
Setting DisableTokenSigningCertificateValidation to True
Setting ExtendedSecurityTokenLifetime to 24
```