### PR TITLE
App Resolutions not working correctly with lower runtimes.

### DIFF
--- a/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
+++ b/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
@@ -100,6 +100,10 @@ try {
                 $appJson.dependencies | % {
                     if ($_.psobject.Properties.name -contains "id") {
                         $id = $_.id
+                    } elseif($_.psobject.Properties.name -contains "appId") {
+                        $id = $_.appId
+                    }
+                    if ($null -ne $id) {
                         if ($id -notin $ignoredDependencies) {
                             try {
                                 $tempAppDependencyFolder = Join-Path $tempAppDependenciesFolder $id

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 3.0.2
 Issue #2280 TypeNotFound on [Path]::GetFileName($vsixUrl)
 Issue - Resolve-DependenciesFromAzureFeed not ignoring first lvl dependencies
+Issue - Resolve-DependenciesFromAzureFeed not working with 4.0 and lower runtimes
 
 3.0.1
 Fix issues with bacpac creation when windows users are present in database.


### PR DESCRIPTION
In runtime 4.0 and lower the app id is present with the the property appId and not id.

https://github.com/microsoft/navcontainerhelper/blob/89c424816ab8c4ae6cfd5f903d50cb24da00cb4e/AppHandling/Extract-AppFileToFolder.ps1#L165-L176