### PR TITLE
Update list of feature flags for Extract-AppFileToFolder

### DIFF
--- a/AppHandling/Extract-AppFileToFolder.ps1
+++ b/AppHandling/Extract-AppFileToFolder.ps1
@@ -208,7 +208,7 @@ try {
         $manifest.Package.ChildNodes | Where-Object { $_.name -eq "Features" } | % { 
             $_.GetEnumerator() | % {
                 $feature = $_.'#text'
-                'TranslationFile','GenerateCaptions' | % {
+                'ExcludeGeneratedTranslations','GenerateCaptions','GenerateLockedTranslations','NoImplicitWith','TranslationFile' | % {
                     if ($feature -eq $_) {
                         $appJson.features += $_
                     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Issue #2349 Run-AlCops/Extract-AppFileToFolder fail if runtime is >=8.0 and no ResourceExposurePolicy is set
 Stop treating AL1026 warning as error by default
 Support for application dependency in Sort-AppFoldersByDependencies
+Support for all manifest (app.json) 'features' in Extract-AppFileToFolder
 
 3.0.3
 Issue #2303 Get-BestGenericImageName sometimes returns an image which is newer than the host OS


### PR DESCRIPTION
**Problem:**
When running Run-AlValidation, some feature flags from the app.json are ignored causing compilation failures later on.

**Solution:**
Update the list of support feature flags.