### PR TITLE
allow whitespaces around IP and Hostnames in hosts file.

### DIFF
--- a/ContainerHandling/updatehosts.ps1
+++ b/ContainerHandling/updatehosts.ps1
@@ -114,12 +114,10 @@ else {
     $sethost = $true
     if ($hostsFile) {
         $hosts = UpdateHostsFile -hostsFile $hostsFile
-        $hosts | Where-Object { $_.ToLowerInvariant().EndsWith('.internal') -and $_.Split(" ").Count -eq 2 } | % {
-            $aHostname = $_.Split(" ")[1]
-            $anIp = $_.Split(" ")[0]
-            Write-Host "Setting $aHostname to $anIp in container hosts file (copy from host hosts file)"
-            UpdateHostsFile -hostsFile $myhostsFile -theHostname $aHostname -theIpAddress $anIp | Out-Null
-            if ($aHostname -eq "host.containerhelper.internal") {
+        $hosts | Where-Object { ($_ -match "^\s*(?<IP>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+(?<HOSTNAME>\S+)") -and $Matches.hostname.ToLowerInvariant().EndsWith('.internal') } | ForEach-Object {        
+            Write-Host "Setting $($Matches.hostname) to $($Matches.ip) in container hosts file (copy from host hosts file)"
+            UpdateHostsFile -hostsFile $myhostsFile -theHostname $Matches.hostname -theIpAddress $Matches.ip | Out-Null
+            if ($Matches.hostname -ieq "host.containerhelper.internal") {
                 $sethost = $false
             }
         }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -11,6 +11,7 @@ Issue #2393 Scopes is wrong when using ClientId, ClientSecret and TenantId in Pu
 Run-AlValidation to check whether app is signed (unless SkipVerification is specified)
 Add flag UpdateDependencies to Run-AlPipeline and Compile-AppInBcContainer to update dependencies in compiled .app files to reference versions used during build
 Allow Flush-ContainerHelperCache to run in parallel on the same host
+Allow whitespaces in hosts file during updatehosts.
 
 3.0.4
 Issue #2349 Run-AlCops/Extract-AppFileToFolder fail if runtime is >=8.0 and no ResourceExposurePolicy is set


### PR DESCRIPTION
Had issues with building a new container with use of external SQL.  Found out that I had some whitespaces in my hosts file.
This resolves the issue.

handles following example lines in hosts file.  (without " of course)
"    192.168.1.190  host.docker.internal  "
"192.168.1.190          host.docker.internal"
