### PR TITLE
Add appFilePath param to Get-BcContainerAppInfo

### DIFF
--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -51,7 +51,8 @@ try {
 
     $args = @{}
     if ($appFilePath) {
-        $args += @{ "Path" = $appFilePath }
+        $containerAppFilePath = Get-BcContainerPath -containerName $containerName -path $appFilePath -throw
+        $args += @{ "Path" = $containerAppFilePath }
     }
     elseif ($symbolsOnly) {
         $args += @{ "SymbolsOnly" = $true }


### PR DESCRIPTION
This PR adds an `-appFilePath` parameter to the `Get-BcContainerAppInfo` function.
This parameter is passed as the `-Path` parameter for the `Get-NAVAppInfo` CmdLet.
For this parameter the `-ServerInstance` parameter should not be passed (this would result in an error).

We were currently missing this parameter set as an option in the BcContainerHelper module.
Please let me know if you have any comments on the implementation.

(Opening a new PR as https://github.com/microsoft/navcontainerhelper/pull/2426 was closed by @freddydk)