### PR TITLE
Dev

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -35,7 +35,8 @@ function Invoke-ScriptInBcContainer {
     }
     if ($useSession) {
         try {
-            Invoke-Command -Session $session -ScriptBlock $scriptblock -ArgumentList $argumentList
+            $newScriptBlock = [Scriptblock]::Create("$($scriptblock.ToString())`n`$cimInstance = Get-CIMInstance Win32_OperatingSystem`nWrite-Host ""Container Free Physical Memory is `$((`$cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb""")
+            Invoke-Command -Session $session -ScriptBlock $newScriptblock -ArgumentList $argumentList
         }
         catch {
             Write-Host -ForegroundColor Red $_.Exception.Message

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -40,44 +40,53 @@ function Invoke-ScriptInBcContainer {
         }
         catch {
             $errorMessage = $_.Exception.Message
+            Write-Host -ForegroundColor Red $errorMessage
+            Write-Host
+            Write-Host "Exception Script Stack Trace:"
+            Write-Host -ForegroundColor Red $_.scriptStackTrace
+            Write-Host
+            Write-Host "PowerShell Call Stack:"
+            Get-PSCallStack | Write-Host -ForegroundColor Red
             try {
                $isOutOfMemory = Invoke-Command -Session $session -ScriptBlock { Param($containerName, $startTime)
                     $cimInstance = Get-CIMInstance Win32_OperatingSystem
-                    Write-Host "Container Free Physical Memory is $(($cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb"
-                    Write-Host -ForegroundColor Yellow "Services in container $containerName"
+                    Write-Host "`nContainer Free Physical Memory: $(($cimInstance.FreePhysicalMemory/1024/1024).ToString('F1',[CultureInfo]::InvariantCulture))Gb"
                     $any = $false
+                    Write-Host "`nServices in container $($containerName):"
                     Get-Service |
                         Where-Object { $_.Name -like "MicrosoftDynamics*" -or $_.Name -like "MSSQL`$*" } |
                         Select-Object -Property name, Status |
-                        ForEach-Object { 
-                            Write-Host "- $($_.Name) is $($_.Status)"
+                        ForEach-Object {
+                            if ($_.Status -eq "Running") {
+                                Write-Host "- $($_.Name) is $($_.Status)"
+                            }
+                            else {
+                                Write-Host -ForegroundColor Red "- $($_.Name) is $($_.Status)"
+                            }
                             $any = $true
                         }
-                    if (!$any) { Write-Host "- No services found" }
+                    if (!$any) { Write-Host -ForegroundColor Red "- No services found" }
                     Write-Host
-                    Write-Host -ForegroundColor Yellow "Event log from container $containerName"
                     $any = $false
                     $isOutOfMemory = $false
                     Get-EventLog -LogName Application | 
                         Where-Object { $_.EntryType -eq "Error" -and $_.TimeGenerated -gt $startTime -and ($_.Source -like "MicrosoftDynamics*" -or $_.Source -like "MSSQL`$*") } | 
                         Select-Object -Property TimeGenerated, Source, Message |
                         ForEach-Object {
-                            Write-Host "- $($_.TimeGenerated.ToString('yyyyMMdd hh:mm:ss')) - $($_.Source)"
+                            if (!$any) {
+                                Write-Host "`nRelevant event log from container $($containerName):"
+                            }
+                            Write-Host -ForegroundColor Red "- $($_.TimeGenerated.ToString('yyyyMMdd hh:mm:ss')) - $($_.Source)"
                             Write-Host -ForegroundColor Gray "`n  $($_.Message.Replace("`n","`n  "))`n"
                             if ($_.Message.Contains('OutOfMemoryException')) { $isOutOfMemory = $true }
                             $any = $true
                         }
-                    if (!$any) { Write-Host "- No eventlog entries found" }
                     $isOutOfMemory
                 } -ArgumentList $containerName, $startTime
                 if ($isOutOfMemory) {
-                    $errorMessage = "Out Of Memory Exception thrown inside container"
+                    $errorMessage = "Out Of Memory Exception thrown inside container $containerName"
                 }
             } catch {}
-            Write-Host -ForegroundColor Red $_.Exception.Message
-            Write-Host -ForegroundColor Red $_.scriptStackTrace
-            Write-Host
-            Get-PSCallStack | Write-Host -ForegroundColor Red
             throw $errorMessage
         }
     } else {

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -40,6 +40,8 @@ function Invoke-ScriptInBcContainer {
         catch {
             try {
                 Invoke-Command -Session $session -ScriptBlock { Param($containerName)
+                    $cimInstance = Get-CIMInstance Win32_OperatingSystem
+                    Write-Host "Container Free Physical Memory is $(($cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb"
                     Write-Host -ForegroundColor Yellow "Services in container $containerName"
                     $any = $false
                     Get-Service |

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -35,10 +35,13 @@ function Invoke-ScriptInBcContainer {
     }
     if ($useSession) {
         try {
-            $newScriptBlock = [Scriptblock]::Create("try { $($scriptblock.ToString()) } catch { `$cimInstance = Get-CIMInstance Win32_OperatingSystem; Write-Host ""Container Free Physical Memory is `$((`$cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb""; throw }")
-            Invoke-Command -Session $session -ScriptBlock $newScriptblock -ArgumentList $argumentList
+            Invoke-Command -Session $session -ScriptBlock $scriptblock -ArgumentList $argumentList
         }
         catch {
+            try {
+                $freeMemory = Invoke-Command -Session $session -ScriptBlock { $cimInstance = Get-CIMInstance Win32_OperatingSystem; $cimInstance.FreePhysicalMemory }
+                Write-Host "Container Free Physical Memory is $(($freeMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb"
+            } catch {}
             Write-Host -ForegroundColor Red $_.Exception.Message
             Write-Host -ForegroundColor Red $_.ScriptStackTrace
             Get-PSCallStack | Write-Host -ForegroundColor Red

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -35,7 +35,7 @@ function Invoke-ScriptInBcContainer {
     }
     if ($useSession) {
         try {
-            $newScriptBlock = [Scriptblock]::Create("$($scriptblock.ToString())`n`$cimInstance = Get-CIMInstance Win32_OperatingSystem`nWrite-Host ""Container Free Physical Memory is `$((`$cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb""")
+            $newScriptBlock = [Scriptblock]::Create("try { $($scriptblock.ToString()) } catch { `$cimInstance = Get-CIMInstance Win32_OperatingSystem; Write-Host ""Container Free Physical Memory is `$((`$cimInstance.FreePhysicalMemory/1024).ToString('F1',[CultureInfo]::InvariantCulture))Mb""; throw }")
             Invoke-Command -Session $session -ScriptBlock $newScriptblock -ArgumentList $argumentList
         }
         catch {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -7,6 +7,8 @@ Add warning when using Desktop OS and process isolation
 Issue #2460 New-BcContainerWizard cannot select all countries with NAV 2018 after the introduction of nlbe and itch countries
 Add parameter -doNotPublishApps to Run-AlPipeline to skip publishing apps, running tests etc. - causes usage of filesonly container
 Fix issue that /ReportSuppressedDiagnostics is sometimes applied when the flag is not available.
+Add debug output (memory, running services and eventlog) when Invoke-ScriptInBcContainer is failing
+Re-throw Out Of Memory exception if container is out of memory when using Invoke-ScriptInBcContainer
 
 3.0.7
 Add --no-cache when building docker images to avoid reuse of faulty layers


### PR DESCRIPTION
Add debug output (memory, running services and eventlog) when Invoke-ScriptInBcContainer is failing
Re-throw Out Of Memory exception if container is out of memory when using Invoke-ScriptInBcContainer