### PR TITLE
Set-BcContainerServerConfiguration and Restart-BcContainerServiceTier added

### DIFF
--- a/BcContainerHelper.psd1
+++ b/BcContainerHelper.psd1
@@ -134,7 +134,8 @@ FunctionsToExport = 'Add-FontsToBcContainer', 'Add-GitToAlProjectFolder',
                'Start-BcContainerAppDataUpgrade', 'Stop-BcContainer', 
                'Sync-BcContainerApp', 'Test-BcContainer', 'UnInstall-BcContainerApp', 
                'UnPublish-BcContainerApp', 'Wait-BcContainerReady', 
-               'Write-BcContainerHelperWelcomeText'
+               'Write-BcContainerHelperWelcomeText', 
+               'Set-BcContainerServerConfiguration', 'Restart-BcContainerServiceTier',
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -307,6 +307,8 @@ if (!$silent) {
 . (Join-Path $PSScriptRoot "ContainerHandling\Get-LatestAlLanguageExtensionUrl.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\Get-AlLanguageExtensionFromArtifacts.ps1")
 . (Join-Path $PSScriptRoot "ContainerHandling\traefik\Add-DomainToTraefikConfig.ps1")
+. (Join-Path $PSScriptRoot "ContainerHandling\Set-BcContainerServerConfiguration.ps1")
+. (Join-Path $PSScriptRoot "ContainerHandling\Restart-BcContainerServiceTier.ps1")
 
 # Object Handling functions
 . (Join-Path $PSScriptRoot "ObjectHandling\Export-NavContainerObjects.ps1")

--- a/ContainerHandling/Restart-BcContainerServiceTier.ps1
+++ b/ContainerHandling/Restart-BcContainerServiceTier.ps1
@@ -1,0 +1,35 @@
+﻿<# 
+ .Synopsis
+  Restarts a Business Central Server instance inside of an Business Central Container.
+ .Description
+  The Restart-BcContainerServiceTier cmldet stops a server instance, and then starts it again.
+  You will typically use the Restart-BcContainerServiceTier cmdlet after you make changes to the 
+  server instance configuration using the Set-BcContainerServerConfiguration cmdlet, because most 
+  configuration changes will not take effect until the server instance is restarted.
+
+  Be aware that when you restart the server instance, all client connections to the server instance are terminated.
+ .Parameter containerName
+  Name of container which Business Central Server you want to restart
+ .Example
+  Restart-BcContainerServiceTier -containerName "MyContainer"
+#>
+function Restart-BcContainerServiceTier {
+    Param (
+        [String] $ContainerName = $bcContainerHelperConfig.defaultContainerName
+    )
+
+$telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
+try {
+    Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock{
+        Get-NavServerInstance | Restart-NAVServerInstance
+    } | Out-Null
+}
+catch {
+    TrackException -telemetryScope $telemetryScope -errorRecord $_
+    throw
+}
+finally {
+    TrackTrace -telemetryScope $telemetryScope
+}
+}
+Export-ModuleMember -Function Restart-BcContainerServiceTier

--- a/ContainerHandling/Set-NavContainerServerConfiguration.ps1
+++ b/ContainerHandling/Set-NavContainerServerConfiguration.ps1
@@ -1,0 +1,40 @@
+﻿<# 
+ .Synopsis
+  Configures settings for a Business Central Server instance.  
+ .Description
+  Use the Set-BcContainerServerConfiguration cmdlet to configure settings for a Business Central Server instance. 
+  Changes to just the configuration file will first take effect when the server instance is restarted.
+ .Parameter containerName
+  Name of the container for which you want to get the server configuration
+ .Parameter KeyName
+  Key of the container for which you want to get the server configuration
+ .Parameter KeyValue
+  Value of the container for which you want to get the server configuration
+ .Example
+  Set-BcContainerServerConfiguration -ContainerName "MyContainer" -KeyName "EnableTaskScheduler" -KeyValue "true"
+#>
+Function Set-BcContainerServerConfiguration {
+    Param (
+        [String] $containerName = $bcContainerHelperConfig.defaultContainerName,
+        [Parameter(Mandatory=$true)]
+        [string] $keyName,
+        [Parameter(Mandatory=$true)]
+        [string] $keyValue
+    )
+
+$telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
+try {
+    Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock{
+        Param($keyName, $keyValue)
+        Get-NavServerInstance | Set-NAVServerConfiguration -KeyName $keyName -KeyValue $keyValue
+    } -argumentList $keyName, $keyValue | Out-Null
+}
+catch {
+    TrackException -telemetryScope $telemetryScope -errorRecord $_
+    throw
+}
+finally {
+    TrackTrace -telemetryScope $telemetryScope
+}
+}
+Export-ModuleMember -Function Set-BcContainerServerConfiguration

--- a/Misc/Write-NavContainerHelperWelcomeText.ps1
+++ b/Misc/Write-NavContainerHelperWelcomeText.ps1
@@ -31,6 +31,7 @@ function Write-BcContainerHelperWelcomeText {
     Write-Host "Stop-BcContainer                Stop Business Central container"
     Write-Host "Start-BcContainer               Start Business Central container"
     Write-Host "Restart-BcContainer             Restart Business Central container"
+    Write-Host "Restart-BcContainerServiceTier  Restarts a Business Central Server instance inside of an Business Central Container"
     Write-Host "Import-BcContainerLicense       Import License to a Business Central container"
     Write-Host "Get-BcContainerSession          Create new session to a Business Central container"
     Write-Host "Remove-BcContainerSession       Remove Business Central container session"
@@ -43,6 +44,7 @@ function Write-BcContainerHelperWelcomeText {
     Write-Host "Backup-BcContainerDatabases     Backup database(s) in Business Central container as bak"
     Write-Host "Extract-FilesFromBcContainerImage Extract files from Business Central container Image"
     Write-Host "Get-BestBcContainerImageName    Get best specific Business Central container Image for your host OS"
+    Write-Host "Set-BcContainerServerConfiguration Configures settings for a Business Central Server instance"
     Write-Host
     Write-Host -ForegroundColor Yellow "Functions for running tests"
     Write-Host "Import-TestToolkitToBcContainer Import TestToolkit to Business Central container"

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,8 @@ Add possible kill switch for pssessions (avoid hanging Remove-BcContainerSession
 Support for obsoleteTagMinAllowedMajorMinor (AS0105) in Run-AlCops, Run-AlValidation and Run-AlPipeline
 Use a PowerShell Job to run bcpt tests to be able to remove files afterwards
 Allow Get-BcContainerAppInfo to be used without explicitely specifying -containerName $containerName, allowing just $containerName
+Add new function Set-BcContainerServerConfiguration to directly configure settings of the Business Central Server instance (without needing Invoke-ScriptInBcContainer)
+Add new function Restart-BcContainerServiceTier to restart only the service tier after configuration changes (often necessary)
 
 3.0.8
 Add new function Get-ALGoAuthContext to get AL-Go for GitHub compatible auth context from bcAuthContext obtained from New-BcAuthContext


### PR DESCRIPTION
I added the `Set-BcContainerServerConfiguration` and `Restart-BcContainerServiceTier` cmdlets to make it easier to change the Service Tier configuration.

Second try of #2488. I messed up the rebase.