### PR TITLE
Fix forceHttpWithTraefik

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1662,7 +1662,11 @@ if ($multitenant) {
         $dlPart = "/${containerName}dl"
         $webclientPart = "/$containerName"
 
-        $baseUrl = "https://$publicDnsName"
+        if ($forceHttpWithTraefik) {
+            $baseUrl = "http://$publicDnsName"
+        } else {
+            $baseUrl = "https://$publicDnsName"
+        }
         $restUrl = $baseUrl + $restPart
         $soapUrl = $baseUrl + $soapPart
         $webclientUrl = $baseUrl + $webclientPart
@@ -1717,7 +1721,7 @@ if ($multitenant) {
                                    "-l `"traefik.dl.port=8080`"",
                                    "-l `"traefik.dl.protocol=http`"",
                                    "-l `"traefik.enable=true`"",
-                                   "-l `"traefik.frontend.entryPoints=https`""
+                                   "-l `"traefik.frontend.entryPoints=$traefikProtocol`""
         )
 
         ("

--- a/ContainerHandling/traefik/template_traefik.toml
+++ b/ContainerHandling/traefik/template_traefik.toml
@@ -13,8 +13,6 @@ endpoint = "npipe:////./pipe/docker_engine"
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-    [entryPoints.http.redirect]
-    entryPoint = "https"
   [entryPoints.https]
   address = ":443"
   [entryPoints.https.tls]

--- a/ContainerHandling/traefik/template_traefik_own.toml
+++ b/ContainerHandling/traefik/template_traefik_own.toml
@@ -13,8 +13,6 @@ endpoint = "npipe:////./pipe/docker_engine"
 [entryPoints]
   [entryPoints.http]
   address = ":80"
-    [entryPoints.http.redirect]
-    entryPoint = "https"
   [entryPoints.https]
   address = ":443"
   [entryPoints.https.tls]


### PR DESCRIPTION
Currently `forceHttpWithTraefik` does not work correctly, because of the following reasons:

1. Public URLs in BC Configuration still pointing at `https://`
2. Traefik is still redirecting `http://` to `https://`
3. Traefik entry point (`traefik.frontend.entryPoints`) still using `https://`

This causes that the Container is up and running, but web client will not be loaded due to cross-site scripting limitations and still complaining about missing certificates, etc.

I fixed this by removing the redirection from traefik toml, using the `$traefikProtocol` (http or https) variable as `traefik.frontend.entryPoints` label and specify protocol for public URLs based and the `forceHttpWithTraefik` switch.