### PR TITLE
Dev

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1564,7 +1564,7 @@ $apps | ForEach-Object {
         "appFile" = $_
         "pfxFile" = $codeSignCertPfxFile
         "pfxPassword" = $codeSignCertPfxPassword
-        "importCertificate" = $codeSignCertIsSelfSigned
+        "importCertificate" = $codeSignCertIsSelfSigned -or $isInsideContainer
     }
 
     Invoke-Command -ScriptBlock $SignBcContainerApp -ArgumentList $Parameters

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -65,7 +65,7 @@ try {
     try {
         Write-Host $sharedPfxFile
         Get-BcContainerPath -containerName $containerName -path $sharedPfxFile | Out-Host
-        
+
         TestPfxCertificate -pfxFile $sharedPfxFile -pfxPassword $pfxPassword -certkind "Codesign"
 
         Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($appFile, $pfxFile, $pfxPassword, $timeStampServer, $digestAlgorithm, $importCertificate)
@@ -110,9 +110,11 @@ try {
             do {
                 try {
                     if ($digestAlgorithm) {
+                        Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /fd $digestAlgorithm /td $digestAlgorithm /tr ""$timeStampServer"" ""$appFile"""
                         & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", "$timeStampServer", "$appFile") | Write-Host
                     }
                     else {
+                        Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /t ""$timeStampServer"" ""$appFile"""
                         & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/t", "$timeStampServer", "$appFile") | Write-Host
                     }
                     break

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -111,7 +111,7 @@ try {
                 try {
                     if ($digestAlgorithm) {
                         Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /fd $digestAlgorithm /td $digestAlgorithm /tr ""$timeStampServer"" ""$appFile"""
-                        & "$signtoolexe" @("sign", "/f", """$pfxFile""", "/p","$unsecurepassword", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", """$timeStampServer""", """$appFile""") | Write-Host
+                        & "$signtoolexe" @("sign", "/f", """$pfxFile""", "/p","""$unsecurepassword""", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", """$timeStampServer""", """$appFile""") | Write-Host
                     }
                     else {
                         Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /t ""$timeStampServer"" ""$appFile"""

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -111,7 +111,7 @@ try {
                 try {
                     if ($digestAlgorithm) {
                         Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /fd $digestAlgorithm /td $digestAlgorithm /tr ""$timeStampServer"" ""$appFile"""
-                        & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", "$timeStampServer", "$appFile") | Write-Host
+                        & "$signtoolexe" @("sign", "/f", """$pfxFile""", "/p","$unsecurepassword", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", """$timeStampServer""", """$appFile""") | Write-Host
                     }
                     else {
                         Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /t ""$timeStampServer"" ""$appFile"""

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -63,6 +63,9 @@ try {
     }
 
     try {
+        Write-Host $sharedPfxFile
+        Get-BcContainerPath -containerName $containerName -path $sharedPfxFile | Out-Host
+        
         TestPfxCertificate -pfxFile $sharedPfxFile -pfxPassword $pfxPassword -certkind "Codesign"
 
         Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($appFile, $pfxFile, $pfxPassword, $timeStampServer, $digestAlgorithm, $importCertificate)
@@ -98,6 +101,9 @@ try {
             }
     
             Write-Host "Signing $appFile"
+            Test-Path $appFile | Out-Host
+            Write-Host "Using cert $pfxfile"
+            Test-Path $pfxFile | Out-Host
             $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
             $maxAttempts = 5

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -63,9 +63,6 @@ try {
     }
 
     try {
-        Write-Host $sharedPfxFile
-        Get-BcContainerPath -containerName $containerName -path $sharedPfxFile | Out-Host
-
         TestPfxCertificate -pfxFile $sharedPfxFile -pfxPassword $pfxPassword -certkind "Codesign"
 
         Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($appFile, $pfxFile, $pfxPassword, $timeStampServer, $digestAlgorithm, $importCertificate)
@@ -101,22 +98,15 @@ try {
                 $signToolExe = (get-item "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\SignTool.exe").FullName
             }
     
-            Write-Host "Signing $appFile"
-            Test-Path $appFile | Out-Host
-            Write-Host "Using cert $pfxfile"
-            Test-Path $pfxFile | Out-Host
             $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
-            $maxAttempts = 10
-            whoami | Out-Host
+            $maxAttempts = 5
             do {
                 try {
                     if ($digestAlgorithm) {
-                        Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /fd $digestAlgorithm /td $digestAlgorithm /tr ""$timeStampServer"" ""$appFile"""
                         & "$signtoolexe" @("sign", "/f", """$pfxFile""", "/p","""$unsecurepassword""", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", """$timeStampServer""", """$appFile""") | Write-Host
                     }
                     else {
-                        Write-Host "$signtoolexe sign /f ""$pfxFile"" /p ""$unsecurepassword"" /t ""$timeStampServer"" ""$appFile"""
                         & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/t", "$timeStampServer", "$appFile") | Write-Host
                     }
                     break

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -107,6 +107,7 @@ try {
             $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
             $maxAttempts = 5
+            whoami | Out-Host
             do {
                 try {
                     if ($digestAlgorithm) {

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -106,7 +106,7 @@ try {
             Test-Path $pfxFile | Out-Host
             $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
-            $maxAttempts = 5
+            $maxAttempts = 10
             whoami | Out-Host
             do {
                 try {

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -72,6 +72,7 @@ try {
     
             if ($importCertificate) {
                 Import-PfxCertificate -FilePath $pfxFile -Password $pfxPassword -CertStoreLocation "cert:\localMachine\root" | Out-Null
+                Import-PfxCertificate -FilePath $pfxFile -Password $pfxPassword -CertStoreLocation "cert:\localMachine\my" | Out-Null
             }
     
             if (!(Test-Path "C:\Windows\System32\msvcr120.dll")) {

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -97,14 +97,15 @@ try {
                 }
                 $signToolExe = (get-item "C:\Program Files (x86)\Windows Kits\10\bin\*\x64\SignTool.exe").FullName
             }
-    
+
+            Write-Host "Signing $appFile"
             $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
             $maxAttempts = 5
             do {
                 try {
                     if ($digestAlgorithm) {
-                        & "$signtoolexe" @("sign", "/f", """$pfxFile""", "/p","""$unsecurepassword""", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", """$timeStampServer""", """$appFile""") | Write-Host
+                        & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/fd", $digestAlgorithm, "/td", $digestAlgorithm, "/tr", "$timeStampServer", "$appFile") | Write-Host
                     }
                     else {
                         & "$signtoolexe" @("sign", "/f", "$pfxFile", "/p","$unsecurepassword", "/t", "$timeStampServer", "$appFile") | Write-Host

--- a/ContainerHandling/Import-NavContainerLicense.ps1
+++ b/ContainerHandling/Import-NavContainerLicense.ps1
@@ -25,10 +25,10 @@ function Import-BcContainerLicense {
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
 
-    $containerLicenseFile = Join-Path $ExtensionsFolder "$containerName\my\license$([System.IO.Path]::GetExtension($licenseFile))"
+    $containerLicenseFile = Join-Path $ExtensionsFolder "$containerName\my\license$([System.IO.Path]::GetExtension($licenseFile.Split('?')[0]))"
     if ($licensefile.StartsWith("https://", "OrdinalIgnoreCase") -or $licensefile.StartsWith("http://", "OrdinalIgnoreCase")) {
         Write-Host "Downloading license file '$($licensefile.Split('?')[0])' to container"
-        (New-Object System.Net.WebClient).DownloadFile($licensefile, $containerlicensefile)
+        Download-File -sourceUrl $licensefile -destinationFile $containerlicensefile
         $text = Get-Content $containerLicenseFile -First 1
         if ($text -like "*<html*" -or $text -like "*<body*") {
             Remove-Item -Path $containerlicenseFile -Force

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -45,6 +45,7 @@ function Invoke-ScriptInBcContainer {
         }
         catch {
             if ($isInsideContainer) {
+                Write-Host "Error trying to establish session, retrying in 5 seconds"
                 Start-Sleep -Seconds 5
                 $session = Get-BcContainerSession -containerName $containerName -silent
             }

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -45,9 +45,12 @@ function Invoke-ScriptInBcContainer {
         }
         catch {
             if ($isInsideContainer) {
-                throw "Unable to establish WinRm session to container $containerName"
+                Start-Sleep -Seconds 5
+                $session = Get-BcContainerSession -containerName $containerName -silent
             }
-            $useSession = $false
+            else {
+                $useSession = $false
+            }
         }
     }
     if ($useSession) {

--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -180,17 +180,26 @@ $startTime = [DateTime]::Now
 " | Add-Content $file
 
             if ($bcContainerHelperConfig.addTryCatchToScriptBlock) {
-                if ($scriptblock.Ast.ParamBlock) {
-                    $script = $scriptBlock.Ast.Extent.text.Replace($scriptblock.Ast.ParamBlock.Extent.Text,'').Trim()
-                    if ($script.StartsWith('{')) {
-                        "`$result = Invoke-Command -ScriptBlock { $($scriptblock.Ast.ParamBlock.Extent.Text) try $script catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } } -ArgumentList `$argumentList" | Add-Content $file
+                $ast = $scriptblock.Ast
+                if ($ast -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                    $ast = $ast.Body
+                }
+                if ($ast -is [System.Management.Automation.Language.ScriptBlockAst]) {
+                    if ($ast.ParamBlock) {
+                        $script = $ast.Extent.text.Replace($ast.ParamBlock.Extent.Text,'').Trim()
+                        if ($script.StartsWith('{')) {
+                            "`$result = Invoke-Command -ScriptBlock { $($ast.ParamBlock.Extent.Text) try $script catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } } -ArgumentList `$argumentList" | Add-Content $file
+                        }
+                        else {
+                            "`$result = Invoke-Command -ScriptBlock { $($ast.ParamBlock.Extent.Text) try { $script } catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } } -ArgumentList `$argumentList" | Add-Content $file
+                        }
                     }
                     else {
-                        "`$result = Invoke-Command -ScriptBlock { $($scriptblock.Ast.ParamBlock.Extent.Text) try { $script } catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } } -ArgumentList `$argumentList" | Add-Content $file
+                        "`$result = Invoke-Command -ScriptBlock { try $($ast.Extent.text) catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } }" | Add-Content $file
                     }
                 }
                 else {
-                    "`$result = Invoke-Command -ScriptBlock { try $($scriptBlock.Ast.Extent.text) catch { ""::EXCEPTION::`$(`$_.Exception.Message)"" } }" | Add-Content $file
+                    throw "Unsupported Scriptblock type $($ast.GetType())"
                 }
 @'
 $exception = $result | Where-Object { $_ -like "::EXCEPTION::*" }

--- a/ContainerHandling/Remove-NavContainerSession.ps1
+++ b/ContainerHandling/Remove-NavContainerSession.ps1
@@ -22,16 +22,11 @@ function Remove-BcContainerSession {
     Process {
         if ($sessions.ContainsKey($containerName)) {
             $session = $sessions[$containerName]
-            if ($killPsSessionProcess) {
+            if ($killPsSessionProcess -and !$isInsideContainer) {
                 $inspect = docker inspect $containerName | ConvertFrom-Json
                 if ($inspect.HostConfig.Isolation -eq "process") {
                     $processID = Invoke-Command -Session $session -ScriptBlock { $PID }
-                    try {
-                        Stop-Process -Id $processID -Force
-                    }
-                    catch {
-                        Remove-PSSession -Session $session
-                    }
+                    Stop-Process -Id $processID -Force
                 }
                 else {
                     Remove-PSSession -Session $session

--- a/ContainerHandling/Remove-NavContainerSession.ps1
+++ b/ContainerHandling/Remove-NavContainerSession.ps1
@@ -26,7 +26,12 @@ function Remove-BcContainerSession {
                 $inspect = docker inspect $containerName | ConvertFrom-Json
                 if ($inspect.HostConfig.Isolation -eq "process") {
                     $processID = Invoke-Command -Session $session -ScriptBlock { $PID }
-                    Stop-Process -Id $processID -Force
+                    try {
+                        Stop-Process -Id $processID -Force
+                    }
+                    catch {
+                        Remove-PSSession -Session $session
+                    }
                 }
                 else {
                     Remove-PSSession -Session $session

--- a/Misc/Download-File.ps1
+++ b/Misc/Download-File.ps1
@@ -68,13 +68,21 @@ try {
             $webClient.DownloadFile($sourceUrl, $destinationFile)
         }
         catch {
-            if ($sourceUrl -like "https://bcartifacts.azureedge.net/*" -or $sourceUrl -like "https://bcinsider.azureedge.net/*" -or $sourceUrl -like "https://bcprivate.azureedge.net/*" -or $sourceUrl -like "https://bcpublicpreview.azureedge.net/*") {
-                $idx = $sourceUrl.IndexOf('.azureedge.net/',[System.StringComparison]::InvariantCultureIgnoreCase)
-                $newSourceUrl = $sourceUrl.Substring(0,$idx) + '.blob.core.windows.net' + $sourceUrl.Substring($idx + 14)
-                Write-Host "Could not download from $($sourceUrl.SubString(0,$idx + 14))/..., retrying from $($newSourceUrl.SubString(0,$idx + 22))/..."
+            try {
+                $waittime = 2 + (Get-Random -Maximum 5 -Minimum 0)
+                if ($sourceUrl -like "https://bcartifacts.azureedge.net/*" -or $sourceUrl -like "https://bcinsider.azureedge.net/*" -or $sourceUrl -like "https://bcprivate.azureedge.net/*" -or $sourceUrl -like "https://bcpublicpreview.azureedge.net/*") {
+                    $idx = $sourceUrl.IndexOf('.azureedge.net/',[System.StringComparison]::InvariantCultureIgnoreCase)
+                    $newSourceUrl = $sourceUrl.Substring(0,$idx) + '.blob.core.windows.net' + $sourceUrl.Substring($idx + 14)
+                    Write-Host "Could not download from $($sourceUrl.SubString(0,$idx + 14))/..., retrying from $($newSourceUrl.SubString(0,$idx + 22))/ in $waittime seconds..."
+                }
+                else {
+                    Write-Host "Error downloading..., retrying in $waittime seconds..."
+                    $newSourceUrl = $sourceUrl
+                }
+                Start-Sleep -Seconds $waittime
                 $webClient.DownloadFile($newSourceUrl, $destinationFile)
             }
-            else {
+            catch {
                 throw (GetExtendedErrorMessage $_)
             }
         }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -5,6 +5,10 @@ New function Invoke-git for invoking Git commands from PowerShell
 Display warning if DisabledTests contains codeunit with a comma in the name (not supported for disabling tests)
 Issue #2533 Import-BcContainerLicenseFile doesn't support secure URL's with query parameters
 Issue #2522 Invoke-ScriptInBCContainer with usePsSession False and a Function as Value for the Scriptblock Param fails
+Add support for running BcContainerHelper inside a container, forcing the use of Volumes for sharing between host and containers
+Run-AlPipeline will not use UpdateHosts when running inside a container
+Establishing sessions from inside a container to another container is done using a username based PS Session
+Do not use KillPsSession when running inside a container
 
 3.0.10
 Issue #2457 Convert-BcAppsToRuntimePackages: allow to set showmycode, keepContainer, include sign app parameters

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ New function Invoke-gh for invoking GitHub CLI commands from PowerShell
 New function Invoke-git for invoking Git commands from PowerShell
 Display warning if DisabledTests contains codeunit with a comma in the name (not supported for disabling tests)
 Issue #2533 Import-BcContainerLicenseFile doesn't support secure URL's with query parameters
+Issue #2522 Invoke-ScriptInBCContainer with usePsSession False and a Function as Value for the Scriptblock Param fails
 
 3.0.10
 Issue #2457 Convert-BcAppsToRuntimePackages: allow to set showmycode, keepContainer, include sign app parameters

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Issue #2378 When running BcContainerHelper without admin rights, the import of a
 New function Invoke-gh for invoking GitHub CLI commands from PowerShell
 New function Invoke-git for invoking Git commands from PowerShell
 Display warning if DisabledTests contains codeunit with a comma in the name (not supported for disabling tests)
+Issue #2533 Import-BcContainerLicenseFile doesn't support secure URL's with query parameters
 
 3.0.10
 Issue #2457 Convert-BcAppsToRuntimePackages: allow to set showmycode, keepContainer, include sign app parameters


### PR DESCRIPTION
Issue #2533 Import-BcContainerLicenseFile doesn't support secure URL's with query parameters
Issue #2522 Invoke-ScriptInBCContainer with usePsSession False and a Function as Value for the Scriptblock Param fails
Add support for running BcContainerHelper inside a container, forcing the use of Volumes for sharing between host and containers
Run-AlPipeline will not use UpdateHosts when running inside a container
Establishing sessions from inside a container to another container is done using a username based PS Session
Do not use KillPsSession when running inside a container