### PR TITLE
Archive evtx file to preserve display information

### DIFF
--- a/ContainerInfo/Get-NavContainerEventLog.ps1
+++ b/ContainerInfo/Get-NavContainerEventLog.ps1
@@ -1,4 +1,4 @@
-﻿<# 
+﻿<#
  .Synopsis
   Get the Event log from a NAV/BC Container as an .evtx file
  .Description
@@ -32,10 +32,12 @@ try {
         New-Item $eventLogFolder -ItemType Directory | Out-Null
     }
     $eventLogName = Join-Path $eventLogFolder ($containerName + ' ' + [DateTime]::Now.ToString("yyyy-MM-dd HH.mm.ss") + ".evtx")
+    $locale = (Get-WinSystemLocale).Name
 
-    Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param([string]$path, [string]$logname) 
+    Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param([string]$path, [string]$logname, [string]$locale)
         wevtutil epl $logname "$path"
-    } -ArgumentList (Get-BcContainerPath -containerName $containerName -Path $eventLogName), $logname
+        wevtutil al "$path" /locale:$locale
+    } -ArgumentList (Get-BcContainerPath -containerName $containerName -Path $eventLogName), $logname, $locale
 
     if ($doNotOpen) {
         $eventLogName


### PR DESCRIPTION
This introduces a fix to the bug mentioned in issue #2581 by using wevtutil's archive functionality to preserve the display information of the container's OS.