### PR TITLE
Dev

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: read
 
+concurrency: CI
+
 defaults:
   run:
     shell: PowerShell

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -6,6 +6,8 @@ on:
 permissions:
   contents: read
 
+concurrency: Release
+
 defaults:
   run:
     shell: PowerShell

--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -48,7 +48,7 @@ function Get-BcContainerAppInfo {
         [Parameter(Mandatory = $false, ParameterSetName = 'Original')]
         [switch] $installedOnly,
         [Parameter(Mandatory = $false)]
-        [switch] $useOldFormat = $bcContainerHelperConfig.UseOldFormatForGetBcContainerAppInfo
+        [switch] $useNewFormat = $bcContainerHelperConfig.UseNewFormatForGetBcContainerAppInfo
     )
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()

--- a/AppHandling/Install-NAVSipCryptoProviderFromNavContainer.ps1
+++ b/AppHandling/Install-NAVSipCryptoProviderFromNavContainer.ps1
@@ -40,10 +40,17 @@ try {
 
     Write-Host "Copy SIP crypto provider from container $containerName"
     Copy-FileFromBcContainer -containerName $containerName -ContainerPath $navSip64Path
-    Copy-FileFromBcContainer -containerName $containerName -ContainerPath $navSip32Path
+    Copy-FileFromBcContainer -containerName $containerName -ContainerPath $navSip32Path -ErrorAction SilentlyContinue
 
-    RegSvr32 /s $navSip32Path
+    if (Test-Path $navSip32Path) {
+        RegSvr32 /s $navSip32Path
+        Write-Host -ForegroundColor Green "$navSip32Path successfully registered."
+    }
+    else {
+        Write-Host "$navSip32Path doesn't exist."
+    }
     RegSvr32 /s $navSip64Path
+    Write-Host -ForegroundColor Green "$navSip64Path successfully registered."
 }
 catch {
     TrackException -telemetryScope $telemetryScope -errorRecord $_

--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -113,7 +113,7 @@ function Get-ContainerHelperConfig {
             "ObjectIdForInternalUse" = 88123
             "WinRmCredentials" = $null
             "WarningPreference" = "SilentlyContinue"
-            "UseOldFormatForGetBcContainerAppInfo" = $false
+            "UseNewFormatForGetBcContainerAppInfo" = $false
         }
 
         if ($isInsider) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,7 +1,7 @@
 3.0.12
 Error in retry method in Get-BcArtifactUrl (3.0.11)
-Fixed array parsing in Get-BcContainerAppInfo
-Added ContainerHelper config UseOldFormatForGetBcContainerAppInfo with which you can force Get-BcContainerAppInfo to return values in old format (Sorry Kamil)
+Fixed array parsing in Get-BcContainerAppInfo (only if -useNewFormat switch is included)
+Added ContainerHelper config UseNewFormatForGetBcContainerAppInfo with which you can force Get-BcContainerAppInfo to return values in new format 
 Issue #2573 improve error message when restoring database on host
 Issue #2575 Backup-BcContainerDatabases doesn't work with external SQL Server (if hosthelperfolder is different from containerhelperfolder)
 Issue #2598 NavSip.dll missing in SysWOW64 on business central 21.0 artifact

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Fixed array parsing in Get-BcContainerAppInfo
 Added ContainerHelper config UseOldFormatForGetBcContainerAppInfo with which you can force Get-BcContainerAppInfo to return values in old format (Sorry Kamil)
 Issue #2573 improve error message when restoring database on host
 Issue #2575 Backup-BcContainerDatabases doesn't work with external SQL Server (if hosthelperfolder is different from containerhelperfolder)
+Issue #2598 NavSip.dll missing in SysWOW64 on business central 21.0 artifact
 
 3.0.11
 Issue #2378 When running BcContainerHelper without admin rights, the import of a certificate is now done in an elevated process (asking for permissions)


### PR DESCRIPTION
Issue #2598 NavSip.dll missing in SysWOW64 on business central 21.0 artifact
Fixed array parsing in Get-BcContainerAppInfo (only if -useNewFormat switch is included)
Added ContainerHelper config UseNewFormatForGetBcContainerAppInfo with which you can force Get-BcContainerAppInfo to return values in new format 
