### PR TITLE
Fix AdditionalCountriesAlways typo

### DIFF
--- a/CreateALGoRepo.ps1
+++ b/CreateALGoRepo.ps1
@@ -1152,7 +1152,7 @@ $Step.Doit {
             -accessControl $settings.AccessControl `
             -country $settings.country `
             -additionalCountries @($settings.additionalCountries.Split(',') | ForEach-Object { $_.Trim() }) `
-            -additionalCountriesAlways:($settings.additionalCountriesAlway -eq "yes") `
+            -additionalCountriesAlways:($settings.additionalCountriesAlways -eq "yes") `
             -versioningStrategy ([int]$settings.VersioningMethod+16*($settings.VersioningStrategy -eq "same")) `
             -updateDependencies:($settings.dependencyStrategy -eq "UpdateDependencies") `
             -generateDependencyArtifact:($settings.generateDependencyArtifact -eq "yes") `


### PR DESCRIPTION
```
The property 'additionalCountriesAlway' cannot be found on this object. Verify that the property exists.
At C:\Program Files\WindowsPowerShell\Modules\BcContainerHelper\4.0.2\CreateALGoRepo.ps1:1154 char:36
+ ... Countries @($settings.additionalCountries.Split(',') | ForEach-Object ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : PropertyNotFoundStrict
```