### PR TITLE
Added api.partner.microsoft.com scope

### DIFF
--- a/AL-Go/New-ALGoAppSourceContext.ps1
+++ b/AL-Go/New-ALGoAppSourceContext.ps1
@@ -17,7 +17,7 @@ function New-ALGoAppSourceContext {
         $appSourceContext = [ordered]@{
             "refreshToken" = $authContext.RefreshToken
             "tenantID" = $authContext.tenantID
-            "scopes" = @("https://api.partner.microsoft.com/.default")
+            "scopes" = $authContext.scopes
         }
     }
 

--- a/AL-Go/New-ALGoAppSourceContext.ps1
+++ b/AL-Go/New-ALGoAppSourceContext.ps1
@@ -10,14 +10,14 @@ function New-ALGoAppSourceContext {
             "clientID" = $authContext.clientID
             "clientSecret" = $authContext.ClientSecret | Get-PlainText
             "tenantID" = $authContext.tenantID
-            "scopes" = $authContext.scopes
+            "scopes" = @("https://api.partner.microsoft.com/.default")
         }
     }
     else {
         $appSourceContext = [ordered]@{
             "refreshToken" = $authContext.RefreshToken
             "tenantID" = $authContext.tenantID
-            "scopes" = $authContext.scopes
+            "scopes" = @("https://api.partner.microsoft.com/.default")
         }
     }
 


### PR DESCRIPTION
Maybe I'm missing a curtial part of the documentation. 
But I didn't find any reference how to setup the authentication with app source.

There were 2 issues I had. 

1. The scope to use for the authentication
2. The way to authorize an app registration against the partner center. 


This change helps with 1. addtionally it might be helpful to mention it here as well https://github.com/microsoft/AL-Go/blob/main/Scenarios/settings.md#appsource-specific-advanced-settings

If you tell me where to document the 2. issue I will do that.
