### PR TITLE
use traefik image with 2022 support

### DIFF
--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -112,7 +112,7 @@ function Get-ContainerHelperConfig {
             "PartnerTelemetryConnectionString" = ""
             "MicrosoftTelemetryConnectionString" = "InstrumentationKey=5b44407e-9750-4a07-abe9-30c3b853821b;IngestionEndpoint=https://southcentralus-0.in.applicationinsights.azure.com/"
             "SendExtendedTelemetryToMicrosoft" = $false
-            "TraefikImage" = "traefik:v1.7-windowsservercore-1809"
+            "TraefikImage" = "tobiasfenster/traefik-for-windows:v1.7.34"
             "ObjectIdForInternalUse" = 88123
             "WinRmCredentials" = $null
             "WarningPreference" = "SilentlyContinue"


### PR DESCRIPTION
As reported in #2713, there seems to be an issue at least in some setups on Win Server 2022 to access the docker engine npipe from hyperv containers. As a fix, this uses a traefik image with a variant for Win Server 2022 so that process isolation can be used