### PR TITLE
Fix multiple layout files with same file name

### DIFF
--- a/AppHandling/Copy-AlSourceFiles.ps1
+++ b/AppHandling/Copy-AlSourceFiles.ps1
@@ -39,6 +39,7 @@ try {
         $files | Where-Object { ($extensions.Contains($_.Extension.ToLowerInvariant())) -and !($_.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) } | ForEach-Object {
     
             $filename = $_.Name
+            $directoryname = $_.DirectoryName
             $content = [System.IO.File]::ReadAllLines($_.FullName)
 
             try {
@@ -133,7 +134,10 @@ try {
                                 $endIdx = $line.LastIndexOf("'")
                                 $layoutFilename = $line.SubString($startIdx, $endIdx-$startIdx)
                                 $layoutFilename = $layoutFilename.SubString($layoutFilename.LastIndexOfAny(@('\','/'))+1)
-                                $layoutFile = $Files | Where-Object { $_.name -eq $layoutFilename }
+                                $layoutFile = $Files | Where-Object { ($_.name -eq $layoutFilename) -and ($_.DirectoryName -eq $DirectoryName)} 
+                                if (!($layoutFile)){
+                                    $layoutFile = $Files | Where-Object { $_.name -eq $layoutFilename }
+                                }
                                 if ($layoutFile) {
                                     $layoutcontent = [System.IO.File]::ReadAllBytes($layoutFile.FullName)
         


### PR DESCRIPTION
In the us localization (BC21) there are multiple rdlc files with the same name. This gives an error when running "Create-AlProjectFolderFromNavContainer". Fix: First search for a rdlc file in the current folder of the report.