### PR TITLE
Using unused pat parameter

### DIFF
--- a/PackageHandling/Publish-BuildOutputToAzureFeed.ps1
+++ b/PackageHandling/Publish-BuildOutputToAzureFeed.ps1
@@ -25,13 +25,16 @@ function Publish-BuildOutputToAzureFeed {
         [string] $feed,
         [Parameter(Mandatory = $true)]
         [string] $path,
-        [Parameter(Mandatory = $true)]
-        [string] $pat
+        [Parameter(Mandatory = $false)]
+        [string] $pat = ''
     )
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
-
+    if($pat -ne '') {
+        Write-Warning "Enviroment Variable AZURE_DEVOPS_EXT_PAT is overridden";
+        $env:AZURE_DEVOPS_EXT_PAT = $pat
+    }
     Get-Childitem –Path (Join-Path $path "\Apps\*.app") | % {
         $basename = $_.Basename
 

--- a/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
+++ b/PackageHandling/Resolve-DependenciesFromAzureFeed.ps1
@@ -28,6 +28,8 @@ function Resolve-DependenciesFromAzureFeed {
         [string] $feed,
         [Parameter(Mandatory = $true)]
         [string] $appsFolder,
+        [Parameter(Mandatory = $false)]
+        [string] $pat = '',
         [string] $outputFolder = (Join-Path $appsFolder '.alpackages'),
         [switch] $runtimePackages,
         [int] $lvl = -1,
@@ -36,7 +38,10 @@ function Resolve-DependenciesFromAzureFeed {
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
-
+    if($pat -ne '') {
+        Write-Warning "Enviroment Variable AZURE_DEVOPS_EXT_PAT is overridden";
+        $env:AZURE_DEVOPS_EXT_PAT = $pat
+    }
     $spaces = ''
     $lvl++
 


### PR DESCRIPTION
This fixes #2765.

It now checks if `--pat` was set and apply the vaule as the enviroment variable. 
This might still break somebodys pipeline if they passed something random in pat. - I've checked my pipeline and I always passed the enviroment variable in.

If we can't accept this, I could include a check to see if AZURE_DEVOPS_EXT_PAT is empty and only use the parameter if no enviroment variable was set before.

But I think If I pass in a explicit paramter that should be used and not some enviroment variable set somewhere. 

There is no way to pass the pat directly to the function because, authentication is usally done through `azure devops login`.