### PR TITLE
Add extra parameters to New-NavImage

### DIFF
--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -10,6 +10,8 @@
   Name of the image getting build. Default is myimage:<tag describing version>.
  .Parameter baseImage
   BaseImage to use. Default is using Get-BestGenericImage to get the best generic image to use.
+ .Parameter databaseBackupPath
+  Path to database backup to use in place of Cronus backup. By default database backup from manifest is used. This parameter can be used to override this and use your custom backup.
  .Parameter registryCredential
   Credentials for the registry for baseImage if you are using a private registry (incl. bcinsider)
  .Parameter isolation
@@ -36,6 +38,7 @@ function New-BcImage {
         [string] $artifactUrl,
         [string] $imageName = "myimage",
         [string] $baseImage = "",
+        [string] $databaseBackupPath = "",
         [PSCredential] $registryCredential,
         [ValidateSet('','process','hyperv')]
         [string] $isolation = "",
@@ -522,6 +525,11 @@ try {
                 if (!$skipDatabase) {
                     $dbPath = Join-Path $navDvdPath "SQLDemoDatabase\CommonAppData\Microsoft\Microsoft Dynamics NAV\ver\Database"
                     New-Item $dbPath -ItemType Directory | Out-Null
+                    if (Test-Path $databaseBackupPath -PathType Leaf)
+                    {
+                        Write-Host "Using database backup from $databaseBackupPath"
+                        $databasePath = $databaseBackupPath
+                    }
                     Write-Host "Copying Database"
                     Copy-Item -path $databasePath -Destination $dbPath -Force
                     if ($licenseFilePath) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Issue #2765 Unused param in Publish-BuildOutputToAzureFeed.ps1
 Fix multiple layout files with same file name in BC21
 Add parameter ContainerEventLogFile to Run-AlPipeline to extract container event log after run
 Add new parameter to Run-TestsInBcContainer - renewClientContextBetweenTests to renew client context between tests
+Add new parameter to New-BcImage - databaseBackupPath which allows selecting custom backup (in place of original backup from artifacts)
 Add new setting renewClientContextBetweenTests as default value for the same parameter in Run-TestsInBcContainer
 Change PR process for ContainerHelper
 Wait for tenants to be ready after Restart-BcContainer


### PR DESCRIPTION
Using the New-NavImage/New-BcImage in our Azure DevOps pipelines I would like to expand this function with a new parameter
-   databaseBackupPath: allows selecting custom backup in place of original backup from artifacts

In our case this will save a lot of time in pipelines, because usually we are using custom database that is based on Cronus but contains all of our library apps and config. Now we need to republish all those apps for every build that depends on our library apps (even so our library apps do not change so often), so every build runs 2-5 min. longer than it could. It might not look so much of a time, but we are using pipelines a lot so it easily accumulates to hours of wait time.

With this parameter we could support scenario like this:
- Every month we run pipeline to rebuild our backups and create base build images for our target BC versions
- Every normal build pipeline uses generated base build images in PR validations and automated testing