### PR TITLE
Fix for feature formatting 

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -615,11 +615,11 @@ try {
         }
 
         if ($features) {
-            $alcParameters +=@("/features:$([string]::Join(',', $features))")
+            $alcParameters +=@("/features:$($features -join ',')")
         }
 
         $preprocessorSymbols | where-Object { $_ } | ForEach-Object { $alcParameters += @("/D:$_") }
-
+         
         Write-Host ".\alc.exe $([string]::Join(' ', $alcParameters))"
 
         & .\alc.exe $alcParameters

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -619,7 +619,7 @@ try {
         }
 
         $preprocessorSymbols | where-Object { $_ } | ForEach-Object { $alcParameters += @("/D:$_") }
-         
+
         Write-Host ".\alc.exe $([string]::Join(' ', $alcParameters))"
 
         & .\alc.exe $alcParameters


### PR DESCRIPTION
LCG files aren't generated 

Repro Steps:

- Run Compile-AppInBcContainer with `-features @("lcgtranslationfile", "generateCaptions")`
- Compiler is invoked with `/features:System.Collections.ArrayList` instead of `/features:lcgtranslationfile,generateCaptions`
