### PR TITLE
Fix value of default timestamp server in doc comments on Sign-NavContainerApp.ps1

### DIFF
--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -14,7 +14,7 @@
  .Parameter pfxPassword
   Password of the certificate pfx file
  .Parameter timeStampServer
-  Specifies the URL of the time stamp server. Default is $bcContainerHelperConfig.timeStampServer, which defaults to http://timestamp.verisign.com/scripts/timestamp.dll
+  Specifies the URL of the time stamp server. Default is $bcContainerHelperConfig.timeStampServer, which defaults to http://timestamp.digicert.com
  .Example
   Sign-BcContainerApp -appFile c:\programdata\bccontainerhelper\myapp.app -pfxFile http://my.secure.url/mycert.pfx -pfxPassword $securePassword
  .Example


### PR DESCRIPTION
Change the default URL of the timestamp server to match value for timeStampServer in $bcContainerHelperConfig