### PR TITLE
Sign without PsSession

### DIFF
--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -64,7 +64,7 @@ try {
     try {
         TestPfxCertificate -pfxFile $sharedPfxFile -pfxPassword $pfxPassword -certkind "Codesign"
 
-        Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($appFile, $pfxFile, $pfxPassword, $timeStampServer, $digestAlgorithm, $importCertificate)
+        Invoke-ScriptInBcContainer -containerName $containerName -useSession:$false -ScriptBlock { Param($appFile, $pfxFile, $pfxPassword, $timeStampServer, $digestAlgorithm, $importCertificate)
 
             function GetExtendedErrorMessage {
                 Param(

--- a/ContainerHandling/Enter-NavContainer.ps1
+++ b/ContainerHandling/Enter-NavContainer.ps1
@@ -21,8 +21,10 @@ function Enter-BcContainer {
         if ($bcContainerHelperConfig.usePsSession) {
             $session = Get-BcContainerSession -containerName $containerName -silent
             Enter-PSSession -Session $session
-            Invoke-Command -Session $session -ScriptBlock {
-                function prompt {"[$env:COMPUTERNAME] PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "}
+            if (!$isPsCore) {
+                Invoke-Command -Session $session -ScriptBlock {
+                    function prompt {"[$env:COMPUTERNAME] PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "}
+                }
             }
         } else {
             if ($isAdministrator) {

--- a/ContainerHandling/Get-NavContainerSession.ps1
+++ b/ContainerHandling/Get-NavContainerSession.ps1
@@ -48,7 +48,7 @@ function Get-BcContainerSession {
                         $cert = New-SelfSignedCertificate -DnsName "dontcare" -CertStoreLocation Cert:\LocalMachine\My
                         winrm create winrm/config/Listener?Address=*+Transport=HTTPS ('@{Hostname="dontcare"; CertificateThumbprint="' + $cert.Thumbprint + '"}')
                         winrm set winrm/config/service/Auth '@{Basic="true"}'
-                        Write-Host "Creating Container user $($credential.UserName)"
+                        Write-Host "`nCreating Container user $($credential.UserName)"
                         New-LocalUser -AccountNeverExpires -PasswordNeverExpires -FullName $credential.UserName -Name $credential.UserName -Password $credential.Password | Out-Null
                         Add-LocalGroupMember -Group administrators -Member $credential.UserName
                     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 4.0.15
+When using Enter-BcContainer in PowerShell 7, the containername prompt was displayed twice
 Support PSSession for PowerShell 7 (or PS5 without running as administrator) by using winrm with a hardcoded user with a password set to the host machine UUID (this user created by New-BcContainerSession if needed)
 New function Compile-AppWithBcCompilerFolder, to compile an app without using containers.
 New function Copy-AppFilesToCompilerFolder, to "install" apps in the symbols folder of a compilerFolder.


### PR DESCRIPTION
+ When using Enter-BcContainer in PowerShell 7, the containername prompt was displayed twice
