### PR TITLE
Added dependencyPublishingOption param to Publish-BcContainerApp function

### DIFF
--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -242,10 +242,7 @@ try {
                 elseif ($syncMode -eq "ForceSync") {
                     $schemaUpdateMode = "forcesync"
                 }
-                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode"
-                if ($PSBoundParameters.ContainsKey('DependencyPublishingOption')) {
-                    $url += "&DependencyPublishingOption=$dependencyPublishingOption"
-                }
+                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode&DependencyPublishingOption=$dependencyPublishingOption"
                 if ($tenant) {
                     $url += "&tenant=$tenant"
                 }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -92,7 +92,9 @@ function Publish-BcContainerApp {
         [string] $PublisherAzureActiveDirectoryTenantId,
         [Hashtable] $bcAuthContext,
         [string] $environment,
-        [switch] $checkAlreadyInstalled
+        [switch] $checkAlreadyInstalled,
+        [ValidateSet('default','ignore','strict')]
+        [string] $dependencyPublishingOption = "ignore"
     )
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
@@ -240,7 +242,7 @@ try {
                 elseif ($syncMode -eq "ForceSync") {
                     $schemaUpdateMode = "forcesync"
                 }
-                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode&dependencyPublishingOption=ignore"
+                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode&DependencyPublishingOption=$dependencyPublishingOption"
                 if ($tenant) {
                     $url += "&tenant=$tenant"
                 }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -242,7 +242,10 @@ try {
                 elseif ($syncMode -eq "ForceSync") {
                     $schemaUpdateMode = "forcesync"
                 }
-                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode&DependencyPublishingOption=$dependencyPublishingOption"
+                $url = "$devServerUrl/dev/apps?SchemaUpdateMode=$schemaUpdateMode"
+                if ($PSBoundParameters.ContainsKey('DependencyPublishingOption')) {
+                    $url += "&DependencyPublishingOption=$dependencyPublishingOption"
+                }
                 if ($tenant) {
                     $url += "&tenant=$tenant"
                 }


### PR DESCRIPTION
When republishing parent app with dependencies using `Publish-BcContainerApp` with option `-useDevEndpoint` request returns **error 422**:

```
Status Code 422 : Unprocessable Entity
The extension <CHILD EXTENSION NAME> <VERSION> cannot be installed because a newer version <CURRENT VERSION> is already installed.
```
Parent app is published and installed, but all dependent apps are uninstalled. 

If `DependencyPublishingOption` is set to **default** error is not returned and dependencies are not uninstalled.

Therefore I suggest to add new parameter to function.
 