### PR TITLE
Allow 3 chars for all analyzer rules i.e. PTE1234

### DIFF
--- a/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
+++ b/AppHandling/Convert-ALCOutputToAzureDevOps.ps1
@@ -43,7 +43,7 @@ try {
 
     foreach($line in $AlcOutput) {
         switch -regex ($line) {
-            "^warning (\w{2}\d{4}):(.*('.*').*|.*)$" {
+            "^warning (\w{2,3}\d{4}):(.*('.*').*|.*)$" {
                 if ($null -ne $Matches[3]) {
                     $file = $Matches[3]
                     if ($file -like "$($basePath)*") {
@@ -83,7 +83,7 @@ try {
                 $hasError = $true
                 break
             }
-            "^(.*)error (\w{2}\d{4}): (.*)$"
+            "^(.*)error (\w{2,3}\d{4}): (.*)$"
             #error AL0999: Internal error: System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException
             {
                 if ($gitHubActions) {
@@ -95,7 +95,7 @@ try {
                 $hasError = $true
                 break
             }
-            "^(.*)\((\d+),(\d+)\): warning (\w{2}\d{4}): (.*)$"
+            "^(.*)\((\d+),(\d+)\): warning (\w{2,3}\d{4}): (.*)$"
             #Prepared for unified warning format
             #Objects\codeunit\Cod50130.name.al(62,30): warning AL0118: The name '"Parent Object"' does not exist in the current context        
             {


### PR DESCRIPTION
Hi Freddy,

This very small PR adds the ability to parse custom 3 character issue codes from alc output. I tried to find a gap for PTE, but without luck. Please see this as a compatibility PR for custom analyzers :).

Some years back, we decided to implement MCP which is not fully covered by the current implementation. 

Thank you,
Carsten
