### PR TITLE
Allow Downloading Core Artifact

### DIFF
--- a/Artifacts/Download-Artifacts.ps1
+++ b/Artifacts/Download-Artifacts.ps1
@@ -322,3 +322,4 @@ finally {
     TrackTrace -telemetryScope $telemetryScope
 }
 }
+Export-ModuleMember -Function Download-Artifacts


### PR DESCRIPTION
You would then be able to download the core artifact like: 
Download-Artifacts -artifactUrl (Get-BCArtifactUrl -country 'core') 

Right now this fails when looking for the manifest.json