### PR TITLE
Issue #3051 Unable to import .rapidstart file - The property 'Code' cannot be found on this object

### DIFF
--- a/ConfigPackageHandling/Get-PackageInfoFromRapidStartFile.ps1
+++ b/ConfigPackageHandling/Get-PackageInfoFromRapidStartFile.ps1
@@ -35,7 +35,7 @@ function Get-PackageInfoFromRapidStartFile {
             $readText.Split([Environment]::NewLine) | ForEach-Object {
                 if ($_.IndexOf('DataList') -ne -1 ) {
                     [xml]$package = ($_ + '</DataList>')
-                    $package.'DataList'
+                    $packageInfo = $package.'DataList'
                     break
                 }
             }


### PR DESCRIPTION
Issue #3051 Unable to import .rapidstart file - The property 'Code' cannot be found on this object