### PR TITLE
Add parameters for scripts to run pre and post compilation

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -187,6 +187,19 @@
         [ref] $compilationParams
     )
     ...
+    # Change the output folder based on the app type
+    switch($appType) {
+        "app" {
+            $compilationParams.Value.appOutputFolder = "MyApps"
+        }
+        "testApp" {
+            $compilationParams.Value.appOutputFolder = "MyTestApps"
+        }
+        "bcptApp" {
+            $compilationParams.Value.appOutputFolder = "MyBcptApps"
+        }
+    }
+    ...
   }
  .Parameter PostCompileApp
   Custom script to run after compiling an app.

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -177,10 +177,10 @@
  .Parameter CompileAppInBcContainer
   Override function parameter for Compile-AppInBcContainer
  .Parameter PreCompileApp
-  Custom script to run before compiling an app. The script will be run only if `useCompilerFolder` switch is set.
+  Custom script to run before compiling an app.
   The script accepts the compilation parameters as a reference parameter.
  .Parameter PostCompileApp
-  Custom script to run after compiling an app. The script will be run only if `useCompilerFolder` switch is set.
+  Custom script to run after compiling an app.
   The script accepts the file path of the produced .app file and the used compilation parameters as parameters.
  .Parameter GetBcContainerAppInfo
   Override function parameter for Get-BcContainerAppInfo
@@ -282,7 +282,6 @@ Param(
     [switch] $doNotPerformUpgrade,
     [switch] $doNotPublishApps,
     [switch] $uninstallRemovedApps,
-    [Parameter(ParameterSetName='UseCompilerFolder')]
     [switch] $useCompilerFolder = $bcContainerHelperConfig.useCompilerFolder,
     [switch] $reUseContainer,
     [switch] $keepContainer,
@@ -310,9 +309,7 @@ Param(
     [scriptblock] $SetBcContainerKeyVaultAadAppAndCertificate,
     [scriptblock] $ImportTestToolkitToBcContainer,
     [scriptblock] $CompileAppInBcContainer,
-    [Parameter(ParameterSetName='UseCompilerFolder')]
     [scriptblock] $PreCompileApp,
-    [Parameter(ParameterSetName='UseCompilerFolder')]
     [scriptblock] $PostCompileApp,
     [scriptblock] $GetBcContainerAppInfo,
     [scriptblock] $PublishBcContainerApp,
@@ -1774,7 +1771,7 @@ Write-Host -ForegroundColor Yellow @'
     $compilationParams = $Parameters + $CopParameters
 
     # Run pre-compile script if specified
-    if($PreCompileApp -and $useCompilerFolder) {
+    if($PreCompileApp) {
         Write-Host "Running custom pre-compilation script..."
 
         Invoke-Command -ScriptBlock $PreCompileApp -ArgumentList ([ref] $compilationParams)
@@ -1806,7 +1803,7 @@ Write-Host -ForegroundColor Yellow @'
     }
 
     # Run post-compile script if specified
-    if($PostCompileApp -and $useCompilerFolder) {
+    if($PostCompileApp) {
         Write-Host "Running custom post-compilation script..."
 
         Invoke-Command -ScriptBlock $PostCompileApp -ArgumentList $appFile, $compilationParams

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -726,7 +726,8 @@ if ($PreCompileApp) {
     Write-Host -ForegroundColor Yellow "Custom pre-compilation script defined."; Write-Host $PreCompileApp.ToString()
 }
 
-if($PostCompileApp) {
+if ($PostCompileApp) {
+
     Write-Host -ForegroundColor Yellow "Custom post-compilation script defined."; Write-Host $PostCompileApp.ToString()
 }
 
@@ -1775,14 +1776,16 @@ Write-Host -ForegroundColor Yellow @'
         )
 
         if($PreCompileApp) {
-            Write-Host "Running custom PreCompileApp"
+            Write-Host "Running custom pre-compilation script..."
+
             Invoke-Command -ScriptBlock $PreCompileApp -ArgumentList $Parameters
         }
 
         $appFile = Compile-AppWithBcCompilerFolder @Parameters
 
         if($PostCompileApp) {
-            Write-Host "Running custom PostCompileApp"
+            Write-Host "Running custom post-compilation script..."
+
             Invoke-Command -ScriptBlock $PostCompileApp -ArgumentList $Parameters
         }
         

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1657,6 +1657,9 @@ Write-Host -ForegroundColor Yellow @'
         "appProjectFolder" = $folder
         "appOutputFolder" = $appOutputFolder
         "appSymbolsFolder" = $appPackagesFolder
+        "isApp" = $app
+        "isTestApp" = $testApp
+        "isBCPTApp" = $bcptTestApp
         "AzureDevOps" = $azureDevOps
         "GitHubActions" = $gitHubActions
         "preProcessorSymbols" = $preProcessorSymbols

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1812,7 +1812,11 @@ Write-Host -ForegroundColor Yellow @'
     catch {
         if ($escapeFromCops) {
             Write-Host "Retrying without Cops"
-            $compilationParams = $Parameters
+
+            # Remove Cops parameters
+            $compilationParamsCopy = $compilationParams.Clone()
+            $compilationParamsCopy.Keys | Where-Object {$_ -in $CopParameters.Keys} | ForEach-Object { $compilationParams.Remove($_) }
+
             if ($useCompilerFolder) {
                 $appFile = Compile-AppWithBcCompilerFolder @compilationParams
             }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Issue #3061 Remove-BcEnvironment without doNotWait stopped working
 Align naming of all SaaS functions. Get-BcEnvironmentUpdateWindow, Get-BcEnvironmentScheduledUpgrade, Get-BcEnvironmentUsedStorage,... (added Alias' for all former names)
 Issue #3071 Restart-BCContainer with renewBindings fails because container is not running
 Add functions for supporting Alpaca Containers
+Add parameters `PreCompileApp` and `PostCompileApp` to `Run-AlPipeline` to allow running custom scripts before and after compiling an app.
 
 5.0.3
 Issue #3051 Unable to import .rapidstart file - The property 'Code' cannot be found on this object


### PR DESCRIPTION
Add parameters `PreCompileApp` and `PostCompileApp` to `Run-AlPipeline`: script blocks to run before and after compiling an app when setting `useCompilerFolder` switch.

TODO:
- [x] Update release notes