### PR TITLE
add logic for using update window at app installation

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 5.0.5
+Add new parameter -useEnvironmentUpdateWindow to Install-BcAppFromAppSource, to schedule installation of apps to run inside update window
 
 5.0.4
 Add new parameter -excludeRuntimePackages to Publish-BcContainerApp, to exclude installation of runtime packages


### PR DESCRIPTION
Hi,

i added the option to use the switch "**useEnvironmentUpdateWindow**" in "**Saas/Install-BcAppFromAppSource.ps1**" and changed the scripts logic accordingly.
Using this switch only schedules the install operation and - of course - does not wait for the operation to be finished.

Also added comment in release notes.

Greetings,
Jeremias