### PR TITLE
Custom Headers for Download-File

### DIFF
--- a/Common/Download-File.ps1
+++ b/Common/Download-File.ps1
@@ -7,6 +7,8 @@
   Url from which the file will get downloaded
  .Parameter destinationFile
   Destinatin for the downloaded file
+ .Parameter Headers
+  Specify a custom header for the request
  .Parameter dontOverwrite
   Specify dontOverwrite if you want top skip downloading if the file already exists
  .Parameter timeout

--- a/Common/Download-File.ps1
+++ b/Common/Download-File.ps1
@@ -20,6 +20,7 @@ function Download-File {
         [string] $sourceUrl,
         [Parameter(Mandatory=$true)]
         [string] $destinationFile,
+        [hashtable] $headers = @{"UserAgent" = "BcContainerHelper $bcContainerHelperVersion" },
         [switch] $dontOverwrite,
         [int]    $timeout = 100
     )
@@ -79,7 +80,7 @@ try {
             $sourceUrl = ReplaceCDN -sourceUrl $sourceUrl
         }
         try {
-            DownloadFileLow -sourceUrl $sourceUrl -destinationFile $destinationFile -dontOverwrite:$dontOverwrite -timeout $timeout
+            DownloadFileLow -sourceUrl $sourceUrl -destinationFile $destinationFile -dontOverwrite:$dontOverwrite -timeout $timeout -headers $headers
         }
         catch {
             try {
@@ -92,7 +93,7 @@ try {
                     Write-Host "Could not download from CDN..., retrying from blob storage in $waittime seconds..."
                 }
                 Start-Sleep -Seconds $waittime
-                DownloadFileLow -sourceUrl $newSourceUrl -destinationFile $destinationFile -dontOverwrite:$dontOverwrite -timeout $timeout
+                DownloadFileLow -sourceUrl $newSourceUrl -destinationFile $destinationFile -dontOverwrite:$dontOverwrite -timeout $timeout -headers $headers
             }
             catch {
                 throw (GetExtendedErrorMessage $_)


### PR DESCRIPTION
In our pipelines we have the need to authenticate using Oauth2 since we have a private storage container, we are using your Download-File in the scripts and I do not want to use a SAS token. I did not find any other way than this, perhaps you have another idea that doesn't need a commit? :)

```
$context = New-BcAuthContext -clientID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
                             -tenantID "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
                             -clientSecret "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" `
                             -scopes "https://storage.azure.com/.default"

$headers = @{ 
    "Authorization" = "Bearer $($context.accessToken)"
    "x-ms-version" = "2017-11-09"
}

Download-File -sourceUrl "https://storage.blob.core.windows.net/container/file.file" `
              -destinationFile "c:\temp\file.file" `
              -headers $headers
```