### PR TITLE
add Switch "getCompanyInfo" to "New-BcEnvironment"

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,5 @@
 5.0.6
-Add switch "getCompanyInfo" to "New-BcEnvironment" to enable getting environment information after creation only when needed.
+Add switch "doNotGetCompanyInfo" to "New-BcEnvironment" to enable skipping getting environment information after environment creation.
 Issue #3151 Get-AppSourceProduct returns 404 Not Found
 Add parameters exclusiveAccessTicket, path, syncMode, force and skipVersionCheck to Start-BcContainerAppDataUpgrade.
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 5.0.6
+Add switch "getCompanyInfo" to "New-BcEnvironment" to enable getting environment information after creation only when needed.
 Issue #3151 Get-AppSourceProduct returns 404 Not Found
 
 5.0.5

--- a/Saas/New-BcEnvironment.ps1
+++ b/Saas/New-BcEnvironment.ps1
@@ -25,7 +25,7 @@
  .Parameter doNotWait
   Include this switch if you don't want to wait for completion of the environment
  .Parameter getCompanyInfo
-  Include this switch if you don't want to wait for completion of the environment
+  Include this switch if you want to list the companies after creating the environment. Uses the Business Central Automation API.
  .Example
   $authContext = New-BcAuthContext -includeDeviceLogin
   New-BcEnvironment -bcAuthContext $authContext -countryCode 'us' -environment 'usSandbox'

--- a/Saas/New-BcEnvironment.ps1
+++ b/Saas/New-BcEnvironment.ps1
@@ -24,8 +24,8 @@
   API version. Default is 2.3.
  .Parameter doNotWait
   Include this switch if you don't want to wait for completion of the environment
- .Parameter getCompanyInfo
-  Include this switch if you want to list the companies after creating the environment. Uses the Business Central Automation API.
+ .Parameter doNotGetCompanyInfo
+  Include this switch if you want to skip getting company information via the Automation API.
  .Example
   $authContext = New-BcAuthContext -includeDeviceLogin
   New-BcEnvironment -bcAuthContext $authContext -countryCode 'us' -environment 'usSandbox'
@@ -46,7 +46,7 @@ function New-BcEnvironment {
         [string] $applicationInsightsKey = "",
         [string] $apiVersion = "v2.18",
         [switch] $doNotWait,
-        [switch] $getCompanyInfo
+        [switch] $doNotGetCompanyInfo
     )
 
     $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
@@ -92,7 +92,7 @@ function New-BcEnvironment {
                 throw "Could not create environment with error: $($Operation.errorMessage)"
             }
 
-            if ($getCompanyInfo.IsPresent) {
+            if (!$doNotGetCompanyInfo.IsPresent) {
                 $automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/v2.0"
                 try {
                     $companies = Invoke-RestMethod -Headers $headers -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing

--- a/Saas/New-BcEnvironment.ps1
+++ b/Saas/New-BcEnvironment.ps1
@@ -24,6 +24,8 @@
   API version. Default is 2.3.
  .Parameter doNotWait
   Include this switch if you don't want to wait for completion of the environment
+ .Parameter getCompanyInfo
+  Include this switch if you don't want to wait for completion of the environment
  .Example
   $authContext = New-BcAuthContext -includeDeviceLogin
   New-BcEnvironment -bcAuthContext $authContext -countryCode 'us' -environment 'usSandbox'
@@ -43,7 +45,8 @@ function New-BcEnvironment {
         [string] $applicationVersion = "",
         [string] $applicationInsightsKey = "",
         [string] $apiVersion = "v2.18",
-        [switch] $doNotWait
+        [switch] $doNotWait,
+        [switch] $getCompanyInfo
     )
 
     $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
@@ -89,20 +92,22 @@ function New-BcEnvironment {
                 throw "Could not create environment with error: $($Operation.errorMessage)"
             }
 
-            $automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/v2.0"
-            try {
-                $companies = Invoke-RestMethod -Headers $headers -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+            if ($getCompanyInfo.IsPresent) {
+                $automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/v2.0"
+                try {
+                    $companies = Invoke-RestMethod -Headers $headers -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+                }
+                catch {
+                    start-sleep -seconds 10
+                    $companies = Invoke-RestMethod -Headers $headers -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+                }
+                Write-Host "Companies in environment:"
+                $companies.value | ForEach-Object { Write-Host "- $($_.name)" }
+                $company = $companies.value | Select-Object -First 1
+                $users = Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($($company.Id))/users" -UseBasicParsing -Headers $headers
+                Write-Host "Users in $($company.name):"
+                $users.value | ForEach-Object { Write-Host "- $($_.DisplayName)" }
             }
-            catch {
-                start-sleep -seconds 10
-                $companies = Invoke-RestMethod -Headers $headers -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
-            }
-            Write-Host "Companies in environment:"
-            $companies.value | ForEach-Object { Write-Host "- $($_.name)" }
-            $company = $companies.value | Select-Object -First 1
-            $users = Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($($company.Id))/users" -UseBasicParsing -Headers $headers
-            Write-Host "Users in $($company.name):"
-            $users.value | ForEach-Object { Write-Host "- $($_.DisplayName)" }
         }
     }
     catch {


### PR DESCRIPTION
Hi,

I added the switch "getCompanyInfo" to the function "New-BcEnvironment".
This allows users to prevent the script from getting environment information like companies via the Automation API after the environment was created.

Without the switch, the Automation API is called right after the environment was created, which results in an error, since the application used for authentication via S2S has not been set in Business Central yet.
This enables using S2S - Authentication for environment creation.

Greetings,
Jeremias 