### PR TITLE
Fixing typo in the code

### DIFF
--- a/AppHandling/Start-NavContainerAppDataUpgrade.ps1
+++ b/AppHandling/Start-NavContainerAppDataUpgrade.ps1
@@ -32,7 +32,7 @@ function  Start-BcContainerAppDataUpgrade {
 
     $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
     try {
-        $containerPath = = ""
+        $containerPath = ""
         if ($path) {
             $containerPath = (Get-BcContainerPath -containerName $containerName -path $path -throw)
         }


### PR DESCRIPTION
There is typo in the code, leading to this error when running Start-BcContainerAppDataUpgrade:

```
The term '=' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```

BCContainerhelper version> 5.0.6-preview1069