### PR TITLE
Added parameter copyCustomCodeCopsToAnalyzersFolder

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Add switch "doNotGetCompanyInfo" to "New-BcEnvironment" to enable skipping getting environment information after environment creation.
 Issue #3151 Get-AppSourceProduct returns 404 Not Found
 Add parameters exclusiveAccessTicket, path, syncMode, force and skipVersionCheck to Start-BcContainerAppDataUpgrade.
+Added switch "copyCustomCodeCopsToAnalyzersFolder" to Compile-AppInBcContainer. This copies passed CustomCodeCops into the alc analyzers folder inside the container.
 
 5.0.5
 Add new option (exitedContainers) on Flush-ContainerHelperCache. Note that exited containers are NOT remove by the all flag, you need all,exitedContainers


### PR DESCRIPTION
Added the parameter copyCustomCodeCopsToAnalyzersFolder to allow to copy custom analyzer dlls to the containers analyzers folder. This makes sure all referenced dlls are in the same place and can be found by custom analyzers.

Parameter CustomCodeCops has been expanded to allow patterns and can also pass non-dll files (configuration). But only dll files are added as custom cops.

Handling of custom cops has been moved below extracting vsix with alc.

Example

```PowerShell
# [...]
$customCops = @("C:\ProgramData\BcContainerHelper\Extensions\bc230de\compile\MC.Dynamics.Bc.Al.ModusCop.*");

Compile-AppInBcContainer -containerName bc230de -tenant default -appProjectFolder $appProjectFolder -appOutputFolder $outputFolder -appSymbolsFolder  $appSymbolsFolder `
    -basePath $sharedBasePath -AzureDevOps -CustomCodeCops $customCops -copyCustomCodeCopsToAnalyzersFolder -credential $bcCredential;
```

Sample Output

```
Using Symbols Folder: C:\ProgramData\BcContainerHelper\Extensions\bc230de\compile\OurApp\.alpackages
Copied custom code cop MC.Dynamics.Bc.Al.ModusCop.dll to analyzers folder.
Processing dependency Microsoft_Application_20.1.0.0 ()
Dependency App exists
Processing dependency Microsoft_System_20.0.0.0 ()
Dependency App exists
Processing dependency MODUS Consult GmbH_BaseStuff_20.4.23081401.0 (xxx)
Dependency App exists
Compiling...
.\alc.exe /project:"C:\ProgramData\BcContainerHelper\Extensions\bc230de\compile\OurApp\app" /packagecachepath:"C:\ProgramData\BcContainerHelper\Extensions\bc230de\compile\OurApp\.alpackages" /out:"C:\ProgramData\
BcContainerHelper\Extensions\bc230de\compile\out\OurApp_20.1.23050900.0 .app" /analyzer:C:\build\vsix\extension\bin\Analyzers\MC.Dynamics.Bc.Al.ModusCop.dll /BuildBy:"BcContainerHelper,5.0.5" /assem
blyprobingpaths:"C:\Program Files\dotnet\shared","C:\ProgramData\BcContainerHelper\Extensions\bc230de\.netPackages\Service"
```