### PR TITLE
Latest insider artifacts fail building in compilerfolder

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -500,6 +500,7 @@ try {
                                 $alcPath = 'C:\build\vsix\extension\bin'
                                 Add-Type -Path (Join-Path $alcPath Newtonsoft.Json.dll)
                                 Add-Type -Path (Join-Path $alcPath System.Collections.Immutable.dll)
+                                Add-Type -Path (Join-Path $alcPath System.IO.Packaging.dll)
                                 Add-Type -Path (Join-Path $alcPath Microsoft.Dynamics.Nav.CodeAnalysis.dll)
 
                                 $packageStream = [System.IO.File]::OpenRead($symbolsFile)

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -1147,6 +1147,7 @@ function GetAppInfo {
                     Add-Type -AssemblyName System.Text.Encoding
                     LoadDLL -Path (Join-Path $alcDllPath Newtonsoft.Json.dll)
                     LoadDLL -Path (Join-Path $alcDllPath System.Collections.Immutable.dll)
+		    LoadDLL -Path (Join-Path $alcDllPath System.IO.Packaging.dll)
                     LoadDLL -Path (Join-Path $alcDllPath Microsoft.Dynamics.Nav.CodeAnalysis.dll)
                     $assembliesAdded = $true
                 }


### PR DESCRIPTION
Latest insider artifacts fail building in compilerfolder

`AL-Go action ran: RunPipeline Telemetry Correlation Id: 5f39d8a8-e12d-4443-bbe1-9ffe5b053643
Error: Unexpected error when running action. Error Message: Exception calling "Create" with "2" argument(s): "Could not load file or assembly 'System.IO.Packaging, Version=4.0.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.", StackTrace: at GetAppInfo, C:\ProgramData\BcContainerHelper\6.0.1-preview1082\BcContainerHelper\HelperFunctions.ps1: line 1154 <- at Compile-AppWithBcCompilerFolder, C:\ProgramData\BcContainerHelper\6.0.1-preview1082\BcContainerHelper\CompilerFolderHandling\Compile-AppWithBcCompilerFolder.ps1: line 178 `