### PR TITLE
Add Param dotNotUpdateVersionNumber to New-AppSourceSubmission

### DIFF
--- a/AppSource/New-AppSourceSubmission.ps1
+++ b/AppSource/New-AppSourceSubmission.ps1
@@ -21,6 +21,8 @@
   Include this switch if you do not want the method to display URLs etc.
  .Parameter doNotCheckVersionNumber
   Include this switch avoid checking whether the new version number is greater than the existing version number in Partner Center
+ .Parameter doNotUpdateVersionNumber
+  Include this switch when you do not want to change the version number of the product in Partner Center (can be used for hotfixes) 
  .Example
   New-AppSourceSubmission -authContext $authContext -productId $product.Id -appFile $appFile
  .Example
@@ -40,7 +42,9 @@ function New-AppSourceSubmission {
         [switch] $doNotWait,
         [switch] $force,
         [switch] $silent,
-        [switch] $doNotCheckVersionNumber
+        [Obsolete("doNotCheckVersionNumber is obsolete, please use doNotUpdateVersionNumber instead")]
+        [switch] $doNotCheckVersionNumber,
+        [switch] $doNotUpdateVersionNumber
     )
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
@@ -197,7 +201,7 @@ try {
             }
         )
     }
-    if ($appVersionNumber) {
+    if ($appVersionNumber -and !$doNotUpdateVersionNumber) {
         $branchesProperty = @(Invoke-IngestionApiGetCollection -authContext $authContext -path "/products/$productId/branches/getByModule(module=Property)" -silent:($silent.IsPresent) | Where-Object { 
             $thisVariantID = ''
             if ($_.PSObject.Properties.name -eq "variantID") { $thisVariantID = $_.variantID }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,7 @@
 6.0.1
 New-AadAppsForBC doesn't work with the newer versions of Microsoft.Graph module (where the type of the accesstoken parameter has changed)
+New-AppSourceSubmission has a new parameter -doNotUpdateVersionNumber to support hotfixes in AppSource for earlier versions
+New-AppSourceSubmission obsoleted parameter -doNotCheckVersionNumber that was previously used for hotfixes, because of a change in AppSource
 
 6.0.0
 Add parameter -accept_insiderEULA on New-BcContainer, Get-BcArtifactUrl and Run-AlPipeline to accept the insider EULA (https://go.microsoft.com/fwlink/?linkid=2245051) instead of using the insider SAS token.


### PR DESCRIPTION
fixes #3220 

Hi Freddy,

new AppSource guidelines seem to support hotfixes only when the app version in the offer properties stays untouched.

I thought about reusing the check Param, but the naming would be a bit off.

I tested this with an offer and the hotfix went through validation now.

What do you think?