### PR TITLE
Use Start-Process for Get-BcContainerEventLog

### DIFF
--- a/ContainerInfo/Get-NavContainerEventLog.ps1
+++ b/ContainerInfo/Get-NavContainerEventLog.ps1
@@ -43,7 +43,7 @@ try {
         $eventLogName
     }
     else {
-        [Diagnostics.Process]::Start($eventLogName) | Out-Null
+        Start-Process -FilePath $eventLogName | Out-Null
     }
 }
 catch {


### PR DESCRIPTION
The previous call "[Diagnostics.Process]::Start($eventLogName)"  could not open evtx files correctly inside PowerShell 7.

Fixes #3248