### PR TITLE
Fix CompileResult Format in Compile-AppWithBcCompilerFolder

### DIFF
--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -429,7 +429,7 @@ try {
     Push-Location -Path $alcPath
     try {
         Write-Host "$alcCmd $([string]::Join(' ', $alcParameters))"
-        $result = & $alcCmd $alcParameters | Out-String
+        $result = & $alcCmd $alcParameters
     }
     finally {
         Pop-Location


### PR DESCRIPTION
Remove Out-String for alcCmd return result for correct working Convert-ALCOutputToAzureDevOps
@freddydk this is PullRequest for #3235