### PR TITLE
Renew Access Token

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 6.0.2
+When using Publish-PerTenantExtensionApps with a set of apps, which takes a very long time to publish, the AccessToken might expire and lead to failure. AccessToken is now refreshed when needed.
 
 6.0.1
 New-AadAppsForBC doesn't work with the newer versions of Microsoft.Graph module (where the type of the accesstoken parameter has changed)

--- a/Saas/Publish-PerTenantExtensionApps.ps1
+++ b/Saas/Publish-PerTenantExtensionApps.ps1
@@ -82,7 +82,7 @@ try {
         $automationApiUrl = "$($bcContainerHelperConfig.apiBaseUrl.TrimEnd('/'))/v2.0/$environment/api/microsoft/automation/v2.0"
         
         Write-Host "$automationApiUrl/companies"
-        $companies = Invoke-RestMethod -Headers GetAuthHeaders -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
+        $companies = Invoke-RestMethod -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies" -UseBasicParsing
         $company = $companies.value | Where-Object { ($companyName -eq "") -or ($_.name -eq $companyName) } | Select-Object -First 1
         if (!($company)) {
             throw "No company $companyName"
@@ -91,7 +91,7 @@ try {
         Write-Host "Company '$companyName' has id $companyId"
         
         Write-Host "$automationApiUrl/companies($companyId)/extensions"
-        $getExtensions = Invoke-WebRequest -Headers GetAuthHeaders -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
+        $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
         $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName
         
         if(!$hideInstalledExtensionsOutput) {
@@ -148,20 +148,20 @@ try {
                     Write-Host @newLine "publishing and installing"
                 }
                 if (!$existingApp) {
-                    $extensionUpload = (Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionUpload" -Headers GetAuthHeaders).value
+                    $extensionUpload = (Invoke-RestMethod -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionUpload" -Headers (GetAuthHeaders)).value
                     Write-Host @newLine "."
                     if ($extensionUpload -and $extensionUpload.systemId) {
                         $extensionUpload = Invoke-RestMethod `
                             -Method Patch `
                             -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))" `
-                            -Headers (GetAuthHeaders + $ifMatchHeader + $jsonHeader) `
+                            -Headers ((GetAuthHeaders) + $ifMatchHeader + $jsonHeader) `
                             -Body ($body | ConvertTo-Json -Compress)
                     }
                     else {
                         $ExtensionUpload = Invoke-RestMethod `
                             -Method Post `
                             -Uri "$automationApiUrl/companies($companyId)/extensionUpload" `
-                            -Headers (GetAuthHeaders + $jsonHeader) `
+                            -Headers ((GetAuthHeaders) + $jsonHeader) `
                             -Body ($body | ConvertTo-Json -Compress)
                     }
                     Write-Host @newLine "."
@@ -172,13 +172,13 @@ try {
                     Invoke-RestMethod `
                         -Method Patch `
                         -Uri $extensionUpload.'extensionContent@odata.mediaEditLink' `
-                        -Headers (GetAuthHeaders + $ifMatchHeader + $streamHeader) `
+                        -Headers ((GetAuthHeaders) + $ifMatchHeader + $streamHeader) `
                         -Body $fileBody | Out-Null
                     Write-Host @newLine "."    
                     Invoke-RestMethod `
                         -Method Post `
                         -Uri "$automationApiUrl/companies($companyId)/extensionUpload($($extensionUpload.systemId))/Microsoft.NAV.upload" `
-                        -Headers (GetAuthHeaders + $ifMatchHeader) | Out-Null
+                        -Headers ((GetAuthHeaders) + $ifMatchHeader) | Out-Null
                     Write-Host @newLine "."    
                     $completed = $false
                     $errCount = 0
@@ -187,7 +187,7 @@ try {
                     {
                         Start-Sleep -Seconds $sleepSeconds
                         try {
-                            $extensionDeploymentStatusResponse = Invoke-WebRequest -Headers GetAuthHeaders -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionDeploymentStatus" -UseBasicParsing
+                            $extensionDeploymentStatusResponse = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensionDeploymentStatus" -UseBasicParsing
                             $extensionDeploymentStatuses = (ConvertFrom-Json $extensionDeploymentStatusResponse.Content).value
 
                             $completed = $true
@@ -232,7 +232,7 @@ try {
             throw
         }
         finally {
-            $getExtensions = Invoke-WebRequest -Headers GetAuthHeaders -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
+            $getExtensions = Invoke-WebRequest -Headers (GetAuthHeaders) -Method Get -Uri "$automationApiUrl/companies($companyId)/extensions" -UseBasicParsing
             $extensions = (ConvertFrom-Json $getExtensions.Content).value | Sort-Object -Property DisplayName
             
             if (!$hideInstalledExtensionsOutput) {


### PR DESCRIPTION
When using Publish-PerTenantExtensionApps with a set of apps, which takes a very long time to publish, the AccessToken might expire and lead to failure. AccessToken is now refreshed when needed.
