### PR TITLE
Add enableCodeAnalyzersOnTestApps switch to Run-AlPipeline

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -148,6 +148,8 @@
   Include this switch to include UI Cop during compilation.
  .Parameter enablePerTenantExtensionCop
   Only relevant for Per Tenant Extensions. Include this switch to include Per Tenant Extension Cop during compilation.
+. Parameter enableCodeAnalyzersOnTestApps
+  Include this switch to include CodeCops and other analyzers during compilation of test apps.
  .Parameter customCodeCops
   Use custom AL Cops into the container and include them, in addidtion to the default cops, during compilation.
  .Parameter useDefaultAppSourceRuleSet
@@ -341,6 +343,7 @@ Param(
     [switch] $enableAppSourceCop,
     [switch] $enableUICop,
     [switch] $enablePerTenantExtensionCop,
+    [switch] $enableCodeAnalyzersOnTestApps,
     $customCodeCops = @(),
     [switch] $useDefaultAppSourceRuleSet,
     [string] $rulesetFile = "",
@@ -452,7 +455,6 @@ function GetInstalledAppIds {
         $installedApps = @(GetAppInfo -AppFiles $existingAppFiles -compilerFolder $compilerFolder -cacheAppinfoPath (Join-Path $packagesFolder 'cache_AppInfo.json'))
         $compilerFolderAppFiles = @(Get-ChildItem -Path (Join-Path $compilerFolder 'symbols/*.app') | Select-Object -ExpandProperty FullName)
         $installedApps += @(GetAppInfo -AppFiles $compilerFolderAppFiles -compilerFolder $compilerFolder -cacheAppinfoPath (Join-Path $compilerFolder 'symbols/cache_AppInfo.json'))
-    
     }
     elseif (!$filesOnly) {
         $installedApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters)
@@ -681,6 +683,7 @@ Write-Host -NoNewLine -ForegroundColor Yellow "enableCodeCop                   "
 Write-Host -NoNewLine -ForegroundColor Yellow "enableAppSourceCop              "; Write-Host $enableAppSourceCop
 Write-Host -NoNewLine -ForegroundColor Yellow "enableUICop                     "; Write-Host $enableUICop
 Write-Host -NoNewLine -ForegroundColor Yellow "enablePerTenantExtensionCop     "; Write-Host $enablePerTenantExtensionCop
+Write-Host -NoNewLine -ForegroundColor Yellow "enableCodeAnalyzersOnTestApps   "; Write-Host $enableCodeAnalyzersOnTestApps
 Write-Host -NoNewLine -ForegroundColor Yellow "doNotPerformUpgrade             "; Write-Host $doNotPerformUpgrade
 Write-Host -NoNewLine -ForegroundColor Yellow "doNotPublishApps                "; Write-Host $doNotPublishApps
 Write-Host -NoNewLine -ForegroundColor Yellow "uninstallRemovedApps            "; Write-Host $uninstallRemovedApps
@@ -1639,7 +1642,7 @@ Write-Host -ForegroundColor Yellow @'
         }
     }
 
-    if ($app) {
+    if ($app -or $enableCodeAnalyzersOnTestApps) {
         $CopParameters += @{
             "EnableCodeCop" = $enableCodeCop
             "EnableAppSourceCop" = $enableAppSourceCop

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,7 @@ Add support for useDevEndpoint in Run-AlPipeline when importing test toolkit
 New function Get-AppJsonFromAppFile to extract the app.json file from an app (also from a runtime package)
 New function Copy-AppFilesToFolder to copy or download and unpack all apps from an array of .zip or .app files and place them in a folder
 New function Create-SymbolsFileFromAppFile to create a symbols only app file from an app file
+New switch on Run-AlPipeline, enableCodeAnalyzersOnTestApps, to enable CodeCops and other code analyzers on test apps
 
 6.0.3
 Just-In-Time install dotnet 8.0.0 for Business Central version 24 or above (needed by alc.exe)


### PR DESCRIPTION
Add new switch on `Run-AlPipeline`, `enableCodeAnalyzersOnTestApps`, to enable CodeCops and other code analyzers on test apps.
With these changes, the same analyzer-related settings will be used for both apps and test apps when running `Run-AlPipeline`.