### PR TITLE
companyName should be filled in if it is not assigned in parameter

### DIFF
--- a/Saas/Publish-PerTenantExtensionApps.ps1
+++ b/Saas/Publish-PerTenantExtensionApps.ps1
@@ -88,6 +88,9 @@ try {
             throw "No company $companyName"
         }
         $companyId = $company.id
+        if ($companyName -eq "") {
+            $companyName = $company.name
+        }
         Write-Host "Company '$companyName' has id $companyId"
         
         Write-Host "$automationApiUrl/companies($companyId)/extensions"


### PR DESCRIPTION
@freddydk Added filling in companyName no matter if it is added as parameter in Publish-PerTenantExtensionApps.ps1. Empty companyName could give issues, so in my opinion it should be not empty. Before the change if someone don't add the parameter then the next line of code:
`Write-Host "Company '$companyName' has id $companyId"`
is missing companyName.