### PR TITLE
add dotnet to filesonly

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -391,7 +391,9 @@ try {
         $headers."Authorization" = $bearerAuthValue
     }
     elseif ($serverInstance -eq "") {
-        Write-Host -ForegroundColor Yellow "INFO: You have to specify AuthContext and Environment if you are compiling in a filesOnly container in order to download dependencies"
+        if ($updateSymbols) {
+            Write-Host -ForegroundColor Yellow "INFO: You have to specify AuthContext and Environment if you are compiling in a filesOnly container in order to download dependencies"
+        }
         $devServerUrl = ""
     }
     else {

--- a/AppHandling/Run-AlCops.ps1
+++ b/AppHandling/Run-AlCops.ps1
@@ -131,12 +131,11 @@ function Run-AlCops {
                     Copy-item -Path (Get-Item -Path "c:\run\*.vsix").FullName -Destination $tempZip
                     Expand-Archive -Path $tempZip -DestinationPath "c:\build\vsix"
                 }
-                $binPath = 'C:\build\vsix\extension\bin'
-                $alcPath = Join-Path $binPath 'win32'
-                if (-not (Test-Path $alcPath)) {
-                    $alcPath = $binPath
+                $dllPath = 'C:\build\vsix\extension\bin\Microsoft.Dynamics.Nav.CodeAnalysis.dll'
+                if (-not (Test-Path $dllPath)) {
+                    $dllPath = 'C:\build\vsix\extension\bin\win32\Microsoft.Dynamics.Nav.CodeAnalysis.dll'
                 }
-                Add-Type -Path (Join-Path $alcPath 'Microsoft.Dynamics.Nav.CodeAnalysis.dll') | Out-Null
+                Add-Type -Path $dllPath | Out-Null
                 [Microsoft.Dynamics.Nav.CodeAnalysis.ReleaseVersion]::LatestSupportedRuntimeVersions[$bcversion]
             } -argumentList "$($artifactVersion.Major).$($artifactVersion.Minor)"
         }

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1726,7 +1726,7 @@ Get-NavServerUser -serverInstance $ServerInstance -tenant default |? LicenseType
         ') | Set-Content -Path "$myfolder\SetupVariables.ps1"
     }
 
-    if ($version.Major -ge 22 -and $genericTag -le [System.Version]"1.0.2.13") {
+    if (($version.Major -ge 22 -and $genericTag -le [System.Version]"1.0.2.13") -or ($filesOnly -and $version.Major -ge 22 -and $genericTag -le [System.Version]"1.0.2.14")) {
         if (!(Test-Path -Path "$myfolder\HelperFunctions.ps1")) {
             ('# Invoke default behavior
               . (Join-Path $runPath $MyInvocation.MyCommand.Name)
@@ -1735,7 +1735,7 @@ Get-NavServerUser -serverInstance $ServerInstance -tenant default |? LicenseType
         Write-Host "Patching container to install dotnet 6.0.13"
         Download-File -source "https://download.visualstudio.microsoft.com/download/pr/0cb3c095-c4f4-4d55-929b-3b4888a7b5f1/4156664d6bfcb46b63916a8cd43f8305/dotnet-hosting-6.0.13-win.exe" -destinationFile (Join-Path $myFolder "dotnet-win.exe")
         ('
-if (Test-Path "c:\run\my\dotnet-win.exe") { Write-Host "Generic image is 1.0.2.13 or below, installing dotnet 6.0.13"; start-process -Wait -FilePath "c:\run\my\dotnet-win.exe" -ArgumentList /quiet; Remove-Item "c:\run\my\dotnet-win.exe" -Force }
+if (Test-Path "c:\run\my\dotnet-win.exe") { Write-Host "Installing dotnet 6.0.13"; start-process -Wait -FilePath "c:\run\my\dotnet-win.exe" -ArgumentList /quiet; Remove-Item "c:\run\my\dotnet-win.exe" -Force }
 ') | Add-Content -Path "$myfolder\HelperFunctions.ps1"
     }
 
@@ -1748,7 +1748,7 @@ if (Test-Path "c:\run\my\dotnet-win.exe") { Write-Host "Generic image is 1.0.2.1
         Write-Host "Patching container to install dotnet 8.0.0"
         Download-File -source "https://download.visualstudio.microsoft.com/download/pr/2a7ae819-fbc4-4611-a1ba-f3b072d4ea25/32f3b931550f7b315d9827d564202eeb/dotnet-hosting-8.0.0-win.exe" -destinationFile (Join-Path $myFolder "dotnet-win8.exe")
         ('
-if (Test-Path "c:\run\my\dotnet-win8.exe") { Write-Host "Generic image is 1.0.2.14 or below, installing dotnet 8.0.0"; start-process -Wait -FilePath "c:\run\my\dotnet-win8.exe" -ArgumentList /quiet; Remove-Item "c:\run\my\dotnet-win8.exe" -Force }
+if (Test-Path "c:\run\my\dotnet-win8.exe") { Write-Host "Installing dotnet 8.0.0"; start-process -Wait -FilePath "c:\run\my\dotnet-win8.exe" -ArgumentList /quiet; Remove-Item "c:\run\my\dotnet-win8.exe" -Force }
 ') | Add-Content -Path "$myfolder\HelperFunctions.ps1"
     }
 


### PR DESCRIPTION
Fixes #3301

JIT install dotnet in filesonly containers
Use dotnet framework version of codeanalysis (if it exists)
skip warning unless updatesymbols is set