### PR TITLE
Fix New-BcNuGetPackage for Runtime 3.0 (BC14)

### DIFF
--- a/NuGet/New-BcNuGetPackage.ps1
+++ b/NuGet/New-BcNuGetPackage.ps1
@@ -190,10 +190,15 @@ Function New-BcNuGetPackage {
         $XmlObjectWriter.WriteStartElement("dependencies")
         if ($appJson.PSObject.Properties.Name -eq 'dependencies') {
             $appJson.dependencies | ForEach-Object {
-                $id = CalcPackageId -packageIdTemplate $dependencyIdTemplate -publisher $_.publisher -name $_.name -id $_.id -version $_.version.replace('.','-')
+                if ($_.id) {
+                    $dependencyId = $_.id
+                } else {
+                    $dependencyId = $_.appId
+                }
+                $id = CalcPackageId -packageIdTemplate $dependencyIdTemplate -publisher $_.publisher -name $_.name -id $dependencyId -version $_.version.replace('.','-')
                 $XmlObjectWriter.WriteStartElement("dependency")
-                $XmlObjectWriter.WriteAttributeString("id", $id)
-                $XmlObjectWriter.WriteAttributeString("version", $_.Version)
+                $XmlObjectWriter.WriteAttributeString("id", $dependencyId)
+                $XmlObjectWriter.WriteAttributeString("version", $_.version)
                 $XmlObjectWriter.WriteEndElement()
             }
         }

--- a/NuGet/New-BcNuGetPackage.ps1
+++ b/NuGet/New-BcNuGetPackage.ps1
@@ -197,7 +197,7 @@ Function New-BcNuGetPackage {
                 }
                 $id = CalcPackageId -packageIdTemplate $dependencyIdTemplate -publisher $_.publisher -name $_.name -id $dependencyId -version $_.version.replace('.','-')
                 $XmlObjectWriter.WriteStartElement("dependency")
-                $XmlObjectWriter.WriteAttributeString("id", $dependencyId)
+                $XmlObjectWriter.WriteAttributeString("id", $id)
                 $XmlObjectWriter.WriteAttributeString("version", $_.version)
                 $XmlObjectWriter.WriteEndElement()
             }

--- a/NuGet/New-BcNuGetPackage.ps1
+++ b/NuGet/New-BcNuGetPackage.ps1
@@ -190,7 +190,7 @@ Function New-BcNuGetPackage {
         $XmlObjectWriter.WriteStartElement("dependencies")
         if ($appJson.PSObject.Properties.Name -eq 'dependencies') {
             $appJson.dependencies | ForEach-Object {
-                if ($_.id) {
+                if ($_.PSObject.Properties.name -eq 'id') {
                     $dependencyId = $_.id
                 } else {
                     $dependencyId = $_.appId

--- a/NuGet/New-BcNuGetPackage.ps1
+++ b/NuGet/New-BcNuGetPackage.ps1
@@ -8,7 +8,7 @@
  .Parameter countrySpecificAppFiles
   Hashtable with country specific app files (runtime packages) to include in the NuGet package
  .Parameter packageId
-  Id of the NuGet package (or template to generate the id, replacing {id}, {name} and {publisher} with the values from the app.json file) 
+  Template to generate the id, replacing {id}, {name} and {publisher} with the values from the app.json file
   The default is '{publisher}.{name}.{id}'
  .Parameter packageVersion
   Version of the NuGet package


### PR DESCRIPTION
BC14 (runtime 3.0) does not use `id` as JSON key for the dependencies. Instead `appId` is used. `New-BcNuGetPackage` expects `id` key, which results in the following error:
```cmd
2024-01-24T09:17:47.2437517Z ##[error]ForEach-Object : Die Eigenschaft "id" wurde für dieses Objekt nicht gefunden. Vergewissern Sie sich, dass die 
Eigenschaft vorhanden ist.
In C:\Program Files\WindowsPowerShell\Modules\BcContainerHelper\6.0.4\NuGet\New-BcNuGetPackage.ps1:192 Zeichen:37
+             $appJson.dependencies | ForEach-Object {
+                                     ~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [ForEach-Object], PropertyNotFoundException
    + FullyQualifiedErrorId : PropertyNotFoundStrict,Microsoft.PowerShell.Commands.ForEachObjectCommand
```

Additionally the description of `packageId` is not correct anymore. In theory you can pass anything there, but in case of dependencies existing the template to replace placeholders is required, otherwise the ID will be the same for all dependencies.