### PR TITLE
fix: escape bakfile environment variable

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1440,7 +1440,7 @@ try {
             $restoreBakFolder = $true
             if (!$multitenant) {
                 $bakFile = Join-Path $bakFolder "database.bak"
-                $parameters += "--env bakfile=$bakFile"
+                $parameters += "--env bakfile=""$bakFile"""
             }
         }
     }
@@ -1467,7 +1467,7 @@ try {
         if ($bakFile.StartsWith($bcContainerHelperConfig.hostHelperFolder, [StringComparison]::OrdinalIgnoreCase)) {
             $bakFile = "$($bcContainerHelperConfig.containerHelperFolder)$($bakFile.Substring($bcContainerHelperConfig.hostHelperFolder.Length))"
         }
-        $parameters += "--env bakfile=$bakFile"
+        $parameters += "--env bakfile=""$bakFile"""
     }
 
     $vsixFile = DetermineVsixFile -vsixFile $vsixFile


### PR DESCRIPTION
While using a custom bak file containing special characters (space and parenthesis), I fall on an exception due to the fact bak path was not escaped.

This fix apply the same encapsulate than the one done for licence file.