### PR TITLE
Problem in Next Major

### DIFF
--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -163,7 +163,7 @@ try {
 
             if ($ShowMyCode -ne "Ignore" -or $replaceDependencies -or $replacePackageId -or $internalsVisibleTo) {
                 Write-Host "Checking dependencies in $appFile"
-                Replace-DependenciesInAppFile -containerName $containerName -Path $appFile -replaceDependencies $replaceDependencies -internalsVisibleTo $internalsVisibleTo -ShowMyCode $ShowMyCode -replacePackageId:$replacePackageId
+                Replace-DependenciesInAppFile -Path $appFile -replaceDependencies $replaceDependencies -internalsVisibleTo $internalsVisibleTo -ShowMyCode $ShowMyCode -replacePackageId:$replacePackageId
             }
 
             if ($copyInstalledAppsToFolder) {

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -149,9 +149,14 @@ try {
             else {
                 # Get Installed apps (if UseDevEndpoint is specified, only get global apps or PTEs)
                 # PublishedAs is either "Global", " PTE" or " Dev" (with leading space)
-                $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
+                $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment
+                Write-Host "InstalledApps1 $($useDevEndPoint.IsPresent):"
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.Version) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
+                $installedApps = $installedApps | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
                     @{ "id" = $_.id; "publisher" = $_.publisher; "name" = $_.displayName; "version" = [System.Version]::new($_.VersionMajor,$_.VersionMinor,$_.VersionBuild,$_.VersionRevision) }
                 }
+                Write-Host "InstalledApps2 $($useDevEndPoint.IsPresent):"
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.Version) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
             }
         }
     }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -150,13 +150,11 @@ try {
                 # Get Installed apps (if UseDevEndpoint is specified, only get global apps or PTEs)
                 # PublishedAs is either "Global", " PTE" or " Dev" (with leading space)
                 $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment
-                Write-Host "InstalledApps1 $($useDevEndPoint.IsPresent):"
+                Write-Host "InstalledApps:"
                 $installedApps | ForEach-Object { Write-Host "- $($_.id) $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.publisher)" }
                 $installedApps = $installedApps | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
                     @{ "id" = $_.id; "publisher" = $_.publisher; "name" = $_.displayName; "version" = [System.Version]::new($_.VersionMajor,$_.VersionMinor,$_.VersionBuild,$_.VersionRevision) }
                 }
-                Write-Host "InstalledApps2 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.id) $($_.name) $($_.version) $($_.publisher)" }
             }
         }
     }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -392,9 +392,9 @@ try {
                 }
                 if ($isCloudBcContainer) {
                     $containerPath = Join-Path 'C:\DL' ([System.IO.Path]::GetFileName($appfile))
-                    Copy-FileToCloudBcContainer -authContext $authContext -containerId $environment -localPath $appFile -containerPath $containerPath
+                    Copy-FileToCloudBcContainer -authContext $bcAuthContext -containerId $environment -localPath $appFile -containerPath $containerPath
                     Invoke-ScriptInCloudBcContainer `
-                        -authContext $authContext `
+                        -authContext $bcAuthContext `
                         -containerId $environment `
                         -ScriptBlock $scriptblock `
                         -ArgumentList $containerPath, $skipVerification, $sync, $install, $upgrade, $tenant, $syncMode, $packageType, $scope, $language, $PublisherAzureActiveDirectoryTenantId, $force, $ignoreIfAppExists

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -151,12 +151,12 @@ try {
                 # PublishedAs is either "Global", " PTE" or " Dev" (with leading space)
                 $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment
                 Write-Host "InstalledApps1 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.Version) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
                 $installedApps = $installedApps | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
                     @{ "id" = $_.id; "publisher" = $_.publisher; "name" = $_.displayName; "version" = [System.Version]::new($_.VersionMajor,$_.VersionMinor,$_.VersionBuild,$_.VersionRevision) }
                 }
                 Write-Host "InstalledApps2 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.Version) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
             }
         }
     }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -151,12 +151,12 @@ try {
                 # PublishedAs is either "Global", " PTE" or " Dev" (with leading space)
                 $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment
                 Write-Host "InstalledApps1 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $($_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.id) $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.publisher)" }
                 $installedApps = $installedApps | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
                     @{ "id" = $_.id; "publisher" = $_.publisher; "name" = $_.displayName; "version" = [System.Version]::new($_.VersionMajor,$_.VersionMinor,$_.VersionBuild,$_.VersionRevision) }
                 }
                 Write-Host "InstalledApps2 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $($_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.id) $($_.name) $($_.version) $($_.publisher)" }
             }
         }
     }

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -151,12 +151,12 @@ try {
                 # PublishedAs is either "Global", " PTE" or " Dev" (with leading space)
                 $installedApps = Get-BcInstalledExtensions -bcAuthContext $bcAuthContext -environment $environment
                 Write-Host "InstalledApps1 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $($_.publisher)" }
                 $installedApps = $installedApps | Where-Object { $_.IsInstalled -and ((-not $useDevEndpoint.IsPresent) -or ($_.PublishedAs -ne ' Dev')) } | ForEach-Object {
                     @{ "id" = $_.id; "publisher" = $_.publisher; "name" = $_.displayName; "version" = [System.Version]::new($_.VersionMajor,$_.VersionMinor,$_.VersionBuild,$_.VersionRevision) }
                 }
                 Write-Host "InstalledApps2 $($useDevEndPoint.IsPresent):"
-                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $(_.publisher)" }
+                $installedApps | ForEach-Object { Write-Host "- $($_.displayName) $($_.VersionMajor).$($_.VersionMinor).$($_.VersionBuild).$($_.VersionRevision) '$($_.PublishedAs)' $($_.IsInstalled) $($_.id) $($_.publisher)" }
             }
         }
     }

--- a/AppHandling/Replace-DependenciesInAppFile.ps1
+++ b/AppHandling/Replace-DependenciesInAppFile.ps1
@@ -40,11 +40,6 @@ Function Replace-DependenciesInAppFile {
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
 
-    if ($path -ne $Destination) {
-        Copy-Item -Path $path -Destination $Destination -Force
-        $path = $Destination
-    }
-    
     if ($isPsCore) {
         [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Packaging') | Out-Null
     }
@@ -73,7 +68,7 @@ try {
         {
             throw "Unsupported package format"
         }
-    
+
         $memoryStream = [System.IO.MemoryStream]::new()
         $fs.Seek($metadataSize, [System.IO.SeekOrigin]::Begin) | Out-Null
         $fs.CopyTo($memoryStream)

--- a/AppHandling/Replace-DependenciesInAppFile.ps1
+++ b/AppHandling/Replace-DependenciesInAppFile.ps1
@@ -45,8 +45,12 @@ try {
         $path = $Destination
     }
     
-    [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Packaging')
-    [System.Reflection.Assembly]::LoadWithPartialName('WindowsBase')
+    if ($isPsCore) {
+        [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Packaging') | Out-Null
+    }
+    else {
+        [System.Reflection.Assembly]::LoadWithPartialName('WindowsBase') | Out-Null
+    }
     
     $memoryStream = $null
     $fs = $null

--- a/AppHandling/Replace-DependenciesInAppFile.ps1
+++ b/AppHandling/Replace-DependenciesInAppFile.ps1
@@ -24,6 +24,7 @@
 #>
 Function Replace-DependenciesInAppFile {
     Param (
+        [obsolete('ContainerName is no longer needed for Replace-DependenciesInAppFile')]
         [string] $containerName = $bcContainerHelperConfig.defaultContainerName,
         [Parameter(Mandatory=$true)]
         [string] $Path,
@@ -44,182 +45,177 @@ try {
         $path = $Destination
     }
     
-    Invoke-ScriptInBCContainer -containerName $containerName -scriptBlock { Param($path, $Destination, $replaceDependencies, $ShowMyCode, $replacePackageId, $replaceVersionNumber, $internalsVisibleTo)
+    [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Packaging')
     
-        add-type -path (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\system.io.packaging.dll").FullName
+    $memoryStream = $null
+    $fs = $null
     
-        $memoryStream = $null
-        $fs = $null
+    try {
     
-        try {
-    
-            $fs = [System.IO.File]::OpenRead($Path)
-            $binaryReader = [System.IO.BinaryReader]::new($fs)
-            $magicNumber1 = $binaryReader.ReadUInt32()
-            $metadataSize = $binaryReader.ReadUInt32()
-            $metadataVersion = $binaryReader.ReadUInt32()
-            $packageId = [Guid]::new($binaryReader.ReadBytes(16))
-            $contentLength = $binaryReader.ReadInt64()
-            $magicNumber2 = $binaryReader.ReadUInt32()
+        $fs = [System.IO.File]::OpenRead($Path)
+        $binaryReader = [System.IO.BinaryReader]::new($fs)
+        $magicNumber1 = $binaryReader.ReadUInt32()
+        $metadataSize = $binaryReader.ReadUInt32()
+        $metadataVersion = $binaryReader.ReadUInt32()
+        $packageId = [Guid]::new($binaryReader.ReadBytes(16))
+        $contentLength = $binaryReader.ReadInt64()
+        $magicNumber2 = $binaryReader.ReadUInt32()
             
-            if ($magicNumber1 -ne 0x5856414E -or 
-                $magicNumber2 -ne 0x5856414E -or 
-                $metadataVersion -gt 2 -or
-                $fs.Position + $contentLength -gt $fs.Length)
-            {
-                throw "Unsupported package format"
+        if ($magicNumber1 -ne 0x5856414E -or 
+            $magicNumber2 -ne 0x5856414E -or 
+            $metadataVersion -gt 2 -or
+            $fs.Position + $contentLength -gt $fs.Length)
+        {
+            throw "Unsupported package format"
+        }
+    
+        $memoryStream = [System.IO.MemoryStream]::new()
+        $fs.Seek($metadataSize, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $fs.CopyTo($memoryStream)
+        $memoryStream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
+        $memoryStream.SetLength($contentLength)
+        $fs.Close()
+        $fs.Dispose()
+        $fs = $null
+            
+        $package = [System.IO.Packaging.Package]::Open($memoryStream, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
+        $manifestPart = $package.GetPart('/NavxManifest.xml')
+        $manifestStream = $manifestPart.GetStream()
+        $manifest = [xml]([System.IO.StreamReader]::new($manifestStream)).ReadToEnd()
+        $manifestStream.Close()
+        $manifestChanges = $false
+        $symbolReferencePart = $package.GetPart('/SymbolReference.json')
+        $symbolReferenceStream = $symbolReferencePart.GetStream()
+        $symbolJson = ([System.IO.StreamReader]::new($symbolReferenceStream)).ReadToEnd()
+        $symbolReferenceStream.Close()
+        $symbolReference = $symbolJson | ConvertFrom-Json
+        $symbolReferenceChanges = $false
+    
+        if ($ShowMyCode -ne "Ignore") {
+            if ($ShowMyCode -eq "Check") {
+                $resexp = $manifest.Package.ChildNodes | Where-Object { $_.name -eq "ResourceExposurePolicy" }
+                if ($resexp) {
+                    if ($resexp.allowDebugging -ne "true" -or $resexp.allowDownloadingSource -ne "true" -or $resexp.includeSourceInSymbolFile -ne "true") {
+                        throw "Application has limited ResourceExposurePolicy"
+                    }
+                }
+                elseif ($manifest.Package.App.ShowMyCode -eq "False") {
+                    throw "Application has ShowMyCode set to False"
+                }
+            } else {
+                $resexp = $manifest.Package.ChildNodes | Where-Object { $_.name -eq "ResourceExposurePolicy" }
+                if ($resexp) {
+                    if ($resexp.allowDebugging -ne "$ShowMyCode" -or $resexp.allowDownloadingSource -ne "$ShowMyCode" -or $resexp.includeSourceInSymbolFile -ne "$ShowMyCode") {
+                        Write-Host "Changing ResourceExposurePolicy properties to $ShowMyCode"
+                        $resexp.allowDebugging = "$showMyCode"
+                        $resexp.allowDownloadingSource = "$showMyCode"
+                        $resexp.includeSourceInSymbolFile = "$showMyCode"
+                        $manifestChanges = $true
+                    }
+                }
+                elseif ($manifest.Package.App.ShowMyCode -ne $ShowMyCode) {
+                    Write-Host "Changing ShowMyCode to $ShowMyCOde"
+                    $manifest.Package.App.ShowMyCode = "$ShowMyCode"
+                    $manifestChanges = $true
+                }
             }
-        
-            $memoryStream = [System.IO.MemoryStream]::new()
-            $fs.Seek($metadataSize, [System.IO.SeekOrigin]::Begin) | Out-Null
-            $fs.CopyTo($memoryStream)
+        }
+
+        if ($replaceDependencies) {
+            $manifest.Package.Dependencies.GetEnumerator() | % {
+                $dependency = $_
+                if ($replaceDependencies.ContainsKey($dependency.id)) {
+                    $newDependency = $replaceDependencies[$dependency.id]
+                    Write-Host "Replacing dependency from $($dependency.id) to $($newDependency.id)"
+                    $dependency.id = $newDependency.id
+                    $dependency.name = $newDependency.name
+                    $dependency.publisher = $newDependency.publisher
+                    $dependency.minVersion = $newDependency.minVersion
+                    $manifestChanges = $true
+                }
+            }
+        }
+
+        if ($internalsVisibleTo) {
+            $internalsVisibleTo | % {
+                $ivt = $_
+                $existing = $manifest.Package.InternalsVisibleTo.GetEnumerator() | Where-Object { $_.id -eq $ivt.id -and $_.name -eq $ivt.name -and $_.publisher -eq $ivt.publisher }
+                if (-not ($existing)) {
+                    Write-Host "Adding Id=$($ivt.Id), Name=$($ivt.Name), Publisher=$($ivt.Publisher) to InternalsVisibleTo"
+                    $element = $manifest.CreateElement("Module","http://schemas.microsoft.com/navx/2015/manifest")
+                    $element.SetAttribute('Id',$ivt.Id)
+                    $element.SetAttribute('Name',$ivt.Name)
+                    $element.SetAttribute('Publisher',$ivt.Publisher)
+                    $manifest.Package.InternalsVisibleTo.AppendChild($element) | Out-Null
+                    $manifestChanges = $true
+                    $symbolReference.InternalsVisibleToModules += @(@{
+                        "AppId" = $ivt.Id
+                        "Name" = $ivt.Name
+                        "Publisher" = $ivt.Publisher
+                    })
+                    $symbolReferenceChanges = $true
+                }
+            }
+        }
+
+        if ($replaceVersionNumber) {
+            Write-Host "Replacing Version Number with $replaceVersionNumber"
+            $manifest.Package.App.Version = $replaceVersionNumber
+            $manifestChanges = $true
+        }
+
+        if ($replacePackageId) {
+            Write-Host "Replacing Package ID with new GUID"
+            $packageId = [Guid]::NewGuid()
+            $manifestChanges = $true
+        }
+    
+        if ($manifestChanges) {
+            $partStream = $manifestPart.GetStream([System.IO.FileMode]::Create)
+            $manifest.Save($partStream)
+            $partStream.Flush()
+            
+            if ($symbolReferenceChanges) {
+                $partStream = $symbolReferencePart.GetStream([System.IO.FileMode]::Create)
+                $memStream = [System.IO.MemoryStream]::new()
+                $strWriter = [System.IO.StreamWriter]::new($memStream)
+                $json = $symbolreference | ConvertTo-Json -depth 99
+                $strWriter.Write($json)
+                $strWriter.Flush()
+                $memStream.Position = 0
+                $memStream.CopyTo($partStream)
+                $partStream.Flush()
+            }
+            $package.Close()
+            
+            $fs = [System.IO.FileStream]::new($Destination, [System.IO.FileMode]::Create)
+            
+            $binaryWriter = [System.IO.BinaryWriter]::new($fs)
+            $binaryWriter.Write([UInt32](0x5856414E))
+            $binaryWriter.Write([UInt32](40))
+            $binaryWriter.Write([UInt32](2))
+            $binaryWriter.Write($packageId.ToByteArray())
+            $binaryWriter.Write([UInt64]($memoryStream.Length))
+            $binaryWriter.Write([UInt32](0x5856414E))
+            
             $memoryStream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
-            $memoryStream.SetLength($contentLength)
+            $memoryStream.CopyTo($fs)
+            
             $fs.Close()
             $fs.Dispose()
             $fs = $null
-            
-            $package = [System.IO.Packaging.Package]::Open($memoryStream, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite)
-            $manifestPart = $package.GetPart('/NavxManifest.xml')
-            $manifestStream = $manifestPart.GetStream()
-            $manifest = [xml]([System.IO.StreamReader]::new($manifestStream)).ReadToEnd()
-            $manifestStream.Close()
-            $manifestChanges = $false
-            $symbolReferencePart = $package.GetPart('/SymbolReference.json')
-            $symbolReferenceStream = $symbolReferencePart.GetStream()
-            $symbolJson = ([System.IO.StreamReader]::new($symbolReferenceStream)).ReadToEnd()
-            $symbolReferenceStream.Close()
-            $symbolReference = $symbolJson | ConvertFrom-Json
-            $symbolReferenceChanges = $false
-    
-            if ($ShowMyCode -ne "Ignore") {
-                if ($ShowMyCode -eq "Check") {
-                    $resexp = $manifest.Package.ChildNodes | Where-Object { $_.name -eq "ResourceExposurePolicy" }
-                    if ($resexp) {
-                        if ($resexp.allowDebugging -ne "true" -or $resexp.allowDownloadingSource -ne "true" -or $resexp.includeSourceInSymbolFile -ne "true") {
-                            throw "Application has limited ResourceExposurePolicy"
-                        }
-                    }
-                    elseif ($manifest.Package.App.ShowMyCode -eq "False") {
-                        throw "Application has ShowMyCode set to False"
-                    }
-                } else {
-                    $resexp = $manifest.Package.ChildNodes | Where-Object { $_.name -eq "ResourceExposurePolicy" }
-                    if ($resexp) {
-                        if ($resexp.allowDebugging -ne "$ShowMyCode" -or $resexp.allowDownloadingSource -ne "$ShowMyCode" -or $resexp.includeSourceInSymbolFile -ne "$ShowMyCode") {
-                            Write-Host "Changing ResourceExposurePolicy properties to $ShowMyCode"
-                            $resexp.allowDebugging = "$showMyCode"
-                            $resexp.allowDownloadingSource = "$showMyCode"
-                            $resexp.includeSourceInSymbolFile = "$showMyCode"
-                            $manifestChanges = $true
-                        }
-                    }
-                    elseif ($manifest.Package.App.ShowMyCode -ne $ShowMyCode) {
-                        Write-Host "Changing ShowMyCode to $ShowMyCOde"
-                        $manifest.Package.App.ShowMyCode = "$ShowMyCode"
-                        $manifestChanges = $true
-                    }
-                }
-            }
-
-            if ($replaceDependencies) {
-                $manifest.Package.Dependencies.GetEnumerator() | % {
-                    $dependency = $_
-                    if ($replaceDependencies.ContainsKey($dependency.id)) {
-                        $newDependency = $replaceDependencies[$dependency.id]
-                        Write-Host "Replacing dependency from $($dependency.id) to $($newDependency.id)"
-                        $dependency.id = $newDependency.id
-                        $dependency.name = $newDependency.name
-                        $dependency.publisher = $newDependency.publisher
-                        $dependency.minVersion = $newDependency.minVersion
-                        $manifestChanges = $true
-                    }
-                }
-            }
-
-            if ($internalsVisibleTo) {
-                $internalsVisibleTo | % {
-                    $ivt = $_
-                    $existing = $manifest.Package.InternalsVisibleTo.GetEnumerator() | Where-Object { $_.id -eq $ivt.id -and $_.name -eq $ivt.name -and $_.publisher -eq $ivt.publisher }
-                    if (-not ($existing)) {
-                        Write-Host "Adding Id=$($ivt.Id), Name=$($ivt.Name), Publisher=$($ivt.Publisher) to InternalsVisibleTo"
-                        $element = $manifest.CreateElement("Module","http://schemas.microsoft.com/navx/2015/manifest")
-                        $element.SetAttribute('Id',$ivt.Id)
-                        $element.SetAttribute('Name',$ivt.Name)
-                        $element.SetAttribute('Publisher',$ivt.Publisher)
-                        $manifest.Package.InternalsVisibleTo.AppendChild($element) | Out-Null
-                        $manifestChanges = $true
-
-                        $symbolReference.InternalsVisibleToModules += @(@{
-                            "AppId" = $ivt.Id
-                            "Name" = $ivt.Name
-                            "Publisher" = $ivt.Publisher
-                        })
-                        $symbolReferenceChanges = $true
-                    }
-                }
-            }
-
-            if ($replaceVersionNumber) {
-                Write-Host "Replacing Version Number with $replaceVersionNumber"
-                $manifest.Package.App.Version = $replaceVersionNumber
-                $manifestChanges = $true
-            }
-
-            if ($replacePackageId) {
-                Write-Host "Replacing Package ID with new GUID"
-                $packageId = [Guid]::NewGuid()
-                $manifestChanges = $true
-            }
-    
-            if ($manifestChanges) {
-                $partStream = $manifestPart.GetStream([System.IO.FileMode]::Create)
-                $manifest.Save($partStream)
-                $partStream.Flush()
-                
-                if ($symbolReferenceChanges) {
-                    $partStream = $symbolReferencePart.GetStream([System.IO.FileMode]::Create)
-                    $memStream = [System.IO.MemoryStream]::new()
-                    $strWriter = [System.IO.StreamWriter]::new($memStream)
-                    $json = $symbolreference | ConvertTo-Json -depth 99
-                    $strWriter.Write($json)
-                    $strWriter.Flush()
-                    $memStream.Position = 0
-                    $memStream.CopyTo($partStream)
-                    $partStream.Flush()
-                }
-
-                $package.Close()
-                
-                $fs = [System.IO.FileStream]::new($Destination, [System.IO.FileMode]::Create)
-                
-                $binaryWriter = [System.IO.BinaryWriter]::new($fs)
-                $binaryWriter.Write([UInt32](0x5856414E))
-                $binaryWriter.Write([UInt32](40))
-                $binaryWriter.Write([UInt32](2))
-                $binaryWriter.Write($packageId.ToByteArray())
-                $binaryWriter.Write([UInt64]($memoryStream.Length))
-                $binaryWriter.Write([UInt32](0x5856414E))
-                
-                $memoryStream.Seek(0, [System.IO.SeekOrigin]::Begin) | Out-Null
-                $memoryStream.CopyTo($fs)
-                
-                $fs.Close()
-                $fs.Dispose()
-                $fs = $null
-            }
-            else {
-                if ($Path -ne $Destination) {
-                    Copy-Item -Path $Path -Destination $Destination -Force
-                }
+        }
+        else {
+            if ($Path -ne $Destination) {
+                Copy-Item -Path $Path -Destination $Destination -Force
             }
         }
-        finally {
-            if ($fs) {
-                $fs.Close()
-            }
+    }
+    finally {
+        if ($fs) {
+            $fs.Close()
         }
-    } -argumentList (Get-BCContainerPath -containerName $containerName -path $path -throw), (Get-BCContainerPath -containerName $containerName -path $Destination -throw), $replaceDependencies, $ShowMyCode, $replacePackageId, $replaceVersionNumber, $internalsVisibleTo
+    }
 }
 catch {
     TrackException -telemetryScope $telemetryScope -errorRecord $_

--- a/AppHandling/Replace-DependenciesInAppFile.ps1
+++ b/AppHandling/Replace-DependenciesInAppFile.ps1
@@ -46,6 +46,7 @@ try {
     }
     
     [System.Reflection.Assembly]::LoadWithPartialName('System.IO.Packaging')
+    [System.Reflection.Assembly]::LoadWithPartialName('WindowsBase')
     
     $memoryStream = $null
     $fs = $null

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -449,10 +449,10 @@ function GetTestToolkitApps {
                 }
     
                 if (!$includeTestLibrariesOnly) {
+                    # Add Tests
                     $apps += "Microsoft_System Application Test.app", "Microsoft_Business Foundation Tests.app" | ForEach-Object {
                         @(get-childitem -Path "C:\Applications\*.*" -recurse -filter $_)
                     }
-                        # Add Tests
                     $apps += @(get-childitem -Path "C:\Applications\*.*" -recurse -filter "Microsoft_Tests-*.app") | Where-Object { $_ -notlike "*\Microsoft_Tests-TestLibraries.app" -and ($version.Major -ge 17 -or ($_ -notlike "*\Microsoft_Tests-Marketing.app")) -and $_ -notlike "*\Microsoft_Tests-SINGLESERVER.app" }
                 }
             }

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -444,13 +444,15 @@ function GetTestToolkitApps {
 
             if (!$includeTestFrameworkOnly) {
                 # Add Test Libraries
-                $apps += "Microsoft_System Application Test Library.app", "Microsoft_Tests-TestLibraries.app" | ForEach-Object {
+                $apps += "Microsoft_System Application Test Library.app", "Microsoft_Business Foundation Test Libraries.app", "Microsoft_Tests-TestLibraries.app" | ForEach-Object {
                     @(get-childitem -Path "C:\Applications\*.*" -recurse -filter $_)
                 }
     
                 if (!$includeTestLibrariesOnly) {
-    
-                    # Add Tests
+                    $apps += "Microsoft_System Application Test.app", "Microsoft_Business Foundation Tests.app" | ForEach-Object {
+                        @(get-childitem -Path "C:\Applications\*.*" -recurse -filter $_)
+                    }
+                        # Add Tests
                     $apps += @(get-childitem -Path "C:\Applications\*.*" -recurse -filter "Microsoft_Tests-*.app") | Where-Object { $_ -notlike "*\Microsoft_Tests-TestLibraries.app" -and ($version.Major -ge 17 -or ($_ -notlike "*\Microsoft_Tests-Marketing.app")) -and $_ -notlike "*\Microsoft_Tests-SINGLESERVER.app" }
                 }
             }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,8 @@
 6.0.6
 Include Microsoft_Business Foundation Test Libraries.app when importing test libraries (and tests)
 Include Microsoft_System Application Test.app and Microsoft_Business Foundation Tests.app when importing tests
+Bug when running Publish-BcContainerApp against a cloud container ($authContext not defined)
+Remove the need for a Container when using Replace-DependenciesInAppFile (containername parameter is now obsolete)
 
 6.0.5
 Proof of concept support for hosting artifacts as Universal Packages

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,6 @@
 6.0.6
+Include Microsoft_Business Foundation Test Libraries.app when importing test libraries (and tests)
+Include Microsoft_System Application Test.app and Microsoft_Business Foundation Tests.app when importing tests
 
 6.0.5
 Proof of concept support for hosting artifacts as Universal Packages


### PR DESCRIPTION
Include Microsoft_Business Foundation Test Libraries.app when importing test libraries (and tests)
Include Microsoft_System Application Test.app and Microsoft_Business Foundation Tests.app when importing tests
Bug when running Publish-BcContainerApp against a cloud container ($authContext not defined)
Remove the need for a Container when using Replace-DependenciesInAppFile (containername parameter is now obsolete)
