### PR TITLE
NuGet fixes

### DIFF
--- a/AppHandling/Sort-AppFilesByDependencies.ps1
+++ b/AppHandling/Sort-AppFilesByDependencies.ps1
@@ -9,6 +9,12 @@
   Array of AppIds. If specified, then include Only Apps in the specified AppFile array or archive which is contained in this Array and their dependencies
  .Parameter unknownDependencies
   If specified, this reference parameter will contain unresolved dependencies after sorting
+ .Parameter excludeRuntimePackages
+  If specified, runtime packages will be ignored
+ .Parameter includeSystemDependencies
+  If specified, dependencies on Microsoft.Application and Microsoft.Platform will be included
+ .Parameter includeDependencyVersion
+  If specified, the version of the dependencies will be included in the output
  .Example
   $files = Sort-AppFilesByDependencies -appFiles @($app1, $app2)
 #>

--- a/BC.HelperFunctions.ps1
+++ b/BC.HelperFunctions.ps1
@@ -112,6 +112,8 @@ function Get-ContainerHelperConfig {
                 "OAuthHostName" = "b52e8b6a-2953-4a08-8e28-5cf45a2dffdc"
                 "OAuthScopes" = "api://b52e8b6a-2953-4a08-8e28-5cf45a2dffdc/.default offline_access"
             }
+            "MSSymbolsNuGetFeedUrl" = 'https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSSymbols/nuget/v3/index.json'
+            "MSAppsNuGetFeedUrl" = 'https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/MSApps/nuget/v3/index.json'
             "TrustedNuGetFeeds" = @(
             )
         }

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -110,7 +110,7 @@ try {
             $existingPlatform = $installedPlatform
         }
         else {
-            $existingPlatform = $installedApps+$returnValue | Where-Object { $_ -and $_.Name -eq 'Platform' } | Select-Object -ExpandProperty Version
+            $existingPlatform = $installedApps | Where-Object { $_ -and $_.Name -eq 'Platform' } | Select-Object -ExpandProperty Version
         }
         if ($existingPlatform -and ([NuGetFeed]::IsVersionIncludedInRange($existingPlatform, $version))) {
             Write-Host "Microsoft.Platform version $existingPlatform is already available"

--- a/NuGet/Find-BcNuGetPackage.ps1
+++ b/NuGet/Find-BcNuGetPackage.ps1
@@ -60,11 +60,12 @@ Function Find-BcNuGetPackage {
             if (!($feed.PSObject.Properties.Name -eq 'Patterns')) { $feed | Add-Member -MemberType NoteProperty -Name 'Patterns' -Value @('*') }
             if (!($feed.PSObject.Properties.Name -eq 'Fingerprints')) { $feed | Add-Member -MemberType NoteProperty -Name 'Fingerprints' -Value @() }
             $nuGetFeed = [NuGetFeed]::Create($feed.Url, $feed.Token, $feed.Patterns, $feed.Fingerprints)
-            $packageIds = $nuGetFeed.Search($packageName)
-            if ($packageIds) {
-                foreach($packageId in $packageIds) {
+            $packages = $nuGetFeed.Search($packageName)
+            if ($packages) {
+                foreach($package in $packages) {
+                    $packageId = $package.Id
                     Write-Host "PackageId: $packageId"
-                    $packageVersion = $nuGetFeed.FindPackageVersion($packageId, $version, $excludeVersions, $select, $allowPrerelease.IsPresent)
+                    $packageVersion = $nuGetFeed.FindPackageVersion($package, $version, $excludeVersions, $select, $allowPrerelease.IsPresent)
                     if (!$packageVersion) {
                         Write-Host "No package found matching version '$version' for package id $($packageId)"
                         continue

--- a/NuGet/NuGetFeedClass.ps1
+++ b/NuGet/NuGetFeedClass.ps1
@@ -104,7 +104,7 @@ class NuGetFeed {
                 if ($result.Count -eq 0) {
                     break
                 }
-                $matching += @($result | Where-Object { $_.name -like "*$packageName*" -and $this.IsTrusted($_.name) } | Sort-Object { $_.id.replace('.symbols','') } | ForEach-Object { @{ "id" = $_.name; "versions" = @() } } )
+                $matching += @($result | Where-Object { $_.name -like "*$packageName*" -and $this.IsTrusted($_.name) } | Sort-Object { $_.name.replace('.symbols','') } | ForEach-Object { @{ "id" = $_.name; "versions" = @() } } )
                 $page++
             }
         }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,6 +3,10 @@ Include Microsoft_Business Foundation Test Libraries.app when importing test lib
 Include Microsoft_System Application Test.app and Microsoft_Business Foundation Tests.app when importing tests
 Bug when running Publish-BcContainerApp against a cloud container ($authContext not defined)
 Remove the need for a Container when using Replace-DependenciesInAppFile (containername parameter is now obsolete)
+Two new parameters on Sort-AppFilesByDependencies (includeSystemDependencies and includeDependencyVersion)
+Add Public Microsoft NuGet Feeds as settings constants
+Fix issues in Download-BcNuGetPackageToFolder, where extensive amounts of NuGet searches was performed to locate packages
+Download-BcNuGetPackageToFolder now returns an array of apps downloaded instead of True/False
 
 6.0.5
 Proof of concept support for hosting artifacts as Universal Packages


### PR DESCRIPTION
Two new parameters on Sort-AppFilesByDependencies (includeSystemDependencies and includeDependencyVersion)
Add Public Microsoft NuGet Feeds as settings constants
Fix issues in Download-BcNuGetPackageToFolder, where extensive amounts of NuGet searches was performed to locate packages
Download-BcNuGetPackageToFolder now returns an array of apps downloaded instead of True/False
