### PR TITLE
Ignore error of New-PSSession -ContainerId

### DIFF
--- a/ContainerHandling/Get-NavContainerSession.ps1
+++ b/ContainerHandling/Get-NavContainerSession.ps1
@@ -43,7 +43,7 @@ function Get-BcContainerSession {
             elseif ($isAdministrator) {
                 try {
                     $containerId = Get-BcContainerId -containerName $containerName
-                    $session = New-PSSession -ContainerId $containerId -RunAsAdministrator
+                    $session = New-PSSession -ContainerId $containerId -RunAsAdministrator -ErrorAction SilentlyContinue
                 }
                 catch {}
             }


### PR DESCRIPTION
When using Pws 7.0, this command fails and rest of the code will fix this by using WinRM. 

When using transcript functionality to log output of scripts, the log is flooded by errors from this line even when it is handled by try-catch:

```
PS>TerminatingError(New-PSSession): "The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: The input ContainerId xxxx does not exist, or the corresponding container is not running."
```