### PR TITLE
NextMajor fixes: Sorting is broken in Get-BcContainerAppInfo 

### DIFF
--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -78,7 +78,7 @@ try {
         $script:installedApps = @()
 
         function AddAnApp { Param($anApp)
-            #Write-Host "AddAnApp $($anapp.Name) $($anapp.Version)"
+            Write-Host "AddAnApp $($anapp.Name) $($anapp.Version)"
             $alreadyAdded = $script:installedApps | Where-Object { $_.AppId -eq $anApp.AppId -and $_.Version -eq $anApp.Version }
             if (-not ($alreadyAdded)) {
                 #Write-Host "add dependencies"
@@ -89,15 +89,15 @@ try {
         }
 
         function AddDependency { Param($dependency)
-            #Write-Host "Add Dependency $($dependency.Name) $($dependency.Version)"
-            $dependentApp = $apps | Where-Object { $_.AppId -eq $dependency.AppId  }
+            Write-Host " -- Add Dependency $($dependency.Name) $($dependency.Version)"
+            $dependentApp = $apps | Where-Object { "$($_.AppId)" -eq "$($dependency.AppId)"  }
             if ($dependentApp) {
                 @($dependentApp) | ForEach-Object { AddAnApp -AnApp $_ }
             }
         }
 
         function AddDependencies { Param($anApp)
-            #Write-Host "Add Dependencies for $($anApp.Name)"
+            # Write-Host "Add Dependencies for $($anApp.Name)"
             if (($anApp) -and ($anApp.Dependencies)) {
                 $anApp.Dependencies | % { AddDependency -Dependency $_ }
             }

--- a/AppHandling/Get-NavContainerAppInfo.ps1
+++ b/AppHandling/Get-NavContainerAppInfo.ps1
@@ -78,7 +78,7 @@ try {
         $script:installedApps = @()
 
         function AddAnApp { Param($anApp)
-            Write-Host "AddAnApp $($anapp.Name) $($anapp.Version)"
+            #Write-Host "AddAnApp $($anapp.Name) $($anapp.Version)"
             $alreadyAdded = $script:installedApps | Where-Object { $_.AppId -eq $anApp.AppId -and $_.Version -eq $anApp.Version }
             if (-not ($alreadyAdded)) {
                 #Write-Host "add dependencies"
@@ -89,7 +89,7 @@ try {
         }
 
         function AddDependency { Param($dependency)
-            Write-Host " -- Add Dependency $($dependency.Name) $($dependency.Version)"
+            #Write-Host "Add Dependency $($dependency.Name) $($dependency.Version)"
             $dependentApp = $apps | Where-Object { "$($_.AppId)" -eq "$($dependency.AppId)"  }
             if ($dependentApp) {
                 @($dependentApp) | ForEach-Object { AddAnApp -AnApp $_ }
@@ -97,7 +97,7 @@ try {
         }
 
         function AddDependencies { Param($anApp)
-            # Write-Host "Add Dependencies for $($anApp.Name)"
+            #Write-Host "Add Dependencies for $($anApp.Name)"
             if (($anApp) -and ($anApp.Dependencies)) {
                 $anApp.Dependencies | % { AddDependency -Dependency $_ }
             }


### PR DESCRIPTION
In BCApps we use Get-BcContainerAppInfo  to get a sorted list of apps so we can uninstall them in the right order. In the latest artifacts they are not sorted in the right order though

See failures in: 
https://github.com/microsoft/BCApps/actions/runs/8015836387
or 
https://github.com/aholstrup1/BCApps/actions/runs/8023595403

With this change, the build passes again
https://github.com/aholstrup1/BCApps/actions/runs/8023619694