### PR TITLE
Mask password value in Run-ALPipeline logs

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -668,7 +668,7 @@ if ($credential) {
 }
 else {
     $password = GetRandomPassword
-    Write-Host "admin/$password"
+    Write-Host "Username: admin, Password: ***"
     $credential= (New-Object pscredential 'admin', (ConvertTo-SecureString -String $password -AsPlainText -Force))
 }
 Write-Host -NoNewLine -ForegroundColor Yellow "CompanyName                     "; Write-Host $companyName


### PR DESCRIPTION
While the password is harmless, it's undesirable to have secrets in logs.