### PR TITLE
Resiliency for Get-WindowsOptionalFeature

### DIFF
--- a/BcContainerHelper.psm1
+++ b/BcContainerHelper.psm1
@@ -31,12 +31,22 @@ if ($useVolumes -or $isInsideContainer) {
 $hypervState = ""
 function Get-HypervState {
     if ($isAdministrator -and $hypervState -eq "") {
-        $feature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -Online
-        if ($feature) {
-            $script:hypervState = $feature.State
+        try {
+            $feature = Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V -Online
+            if ($feature) {
+                $script:hypervState = $feature.State
+            }
+            else {
+                $script:hypervState = "Disabled"
+            }
         }
-        else {
-            $script:hypervState = "Disabled"
+        catch {
+            if ($_.Exception.Message -match "Class not registered") {
+                Write-Host "Cannot check Hyper-V status."
+            }
+            else {
+                throw $_
+            }    
         }
     }
     return $script:hypervState


### PR DESCRIPTION
Solves #3378 by catching the specific error and continue.

This is the output of `New-BcContainer` when running as administrator and having the mentioned issue with `Get-WindowsOptionalFeature -online`:
```
BcContainerHelper is running as administrator
Cannot check Hyper-V status.
HyperV is
```
At least we do not stop anymore with this.