### PR TITLE
Fix concurrent vsixFile download in New-BcCompilerFolder

### DIFF
--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -186,7 +186,7 @@ try {
     if ($vsixFile) {
         # If a vsix file was specified unpack directly to compilerfolder
         Write-Host "Using $vsixFile"
-        $tempZip = Join-Path ([System.IO.Path]::GetTempPath()) "alc.zip"
+        $tempZip = Join-Path ([System.IO.Path]::GetTempPath()) "alc.$containerName.zip"
         Download-File -sourceUrl $vsixFile -destinationFile $tempZip
         Expand-7zipArchive -Path $tempZip -DestinationPath $containerCompilerPath
         if ($isWindows -and $newtonSoftDllPath) {


### PR DESCRIPTION
Fixes a concurrency issue when multiple processes try to use New-BcCompilerFolder with the -vsixFile Parameter

## Problem Description
We use multiple build agents on our build server(s). In high concurrency scenarios like parallel build stages we encounter locking issues when multiple builds try to download the vsix file, because all processes try to save the vsix-tempfile to the same location.

```
Using https://ms-dynamics-smb.gallerycdn.vsassets.io/extensions/ms-dynamics-smb/al/12.6.936426/1707296229269/Microsoft.VisualStudio.Services.VSIXPackage
New-BcCompilerFolder Telemetry Correlation Id: d40bb062-056f-4a96-a47c-8cbee117ac0b
##[error]Remove-Item : Cannot remove item C:\Users\TfsBuild\AppData\Local\Temp\alc.zip: The process cannot access the file 
'C:\Users\TfsBuild\AppData\Local\Temp\alc.zip' because it is being used by another process.
 
```

## Solution Description
By adding the `$containerName` to the temp file name the issue should be resolved. Name does not matter anyway because it is just a tempfile. 