### PR TITLE
use ltsc images

### DIFF
--- a/BC.HelperFunctions.ps1
+++ b/BC.HelperFunctions.ps1
@@ -11,8 +11,8 @@ function Get-ContainerHelperConfig {
     if (!((Get-Variable -scope Script bcContainerHelperConfig -ErrorAction SilentlyContinue) -and $bcContainerHelperConfig)) {
         Set-Variable -scope Script -Name bcContainerHelperConfig -Value @{
             "bcartifactsCacheFolder" = ""
-            "genericImageName" = 'mcr.microsoft.com/businesscentral:{0}'
-            "genericImageNameFilesOnly" = 'mcr.microsoft.com/businesscentral:{0}-filesonly'
+            "genericImageName" = 'mcr.microsoft.com/businesscentral:{1}'
+            "genericImageNameFilesOnly" = 'mcr.microsoft.com/businesscentral:{1}-filesonly'
             "usePsSession" = $true
             "usePwshForBc24" = $true
             "tryWinRmSession" = !$isAdministrator
@@ -120,8 +120,8 @@ function Get-ContainerHelperConfig {
         }
 
         if ($isInsider) {
-            $bcContainerHelperConfig.genericImageName = 'mcr.microsoft.com/businesscentral:{0}-dev'
-            $bcContainerHelperConfig.genericImageNameFilesOnly = 'mcr.microsoft.com/businesscentral:{0}-filesonly-dev'
+            $bcContainerHelperConfig.genericImageName = 'mcr.microsoft.com/businesscentral:{1}-dev'
+            $bcContainerHelperConfig.genericImageNameFilesOnly = 'mcr.microsoft.com/businesscentral:{1}-filesonly-dev'
         }
 
         if ($bcContainerHelperConfigFile -notcontains (Join-Path $programDataFolder "BcContainerHelper.config.json")) {

--- a/ContainerHandling/Get-BestGenericImageName.ps1
+++ b/ContainerHandling/Get-BestGenericImageName.ps1
@@ -32,12 +32,24 @@ try {
         if ($build -eq -1) { $build = [int32]::MaxValue }
         $hostOsVersion = [System.Version]::new($hostOsVersion.Major, $hostOsVersion.Minor, $build, $revision)
     }
-
-    if ($filesOnly) {
-        $genericImageNameSetting = $bcContainerHelperConfig.genericImageNameFilesOnly
+    if ("$hostOsVersion" -lt [System.Version]"10.0.17763.0") {
+        # Everything before Windows Server 2019 uses ltsc2016
+        $ltscVersion = 'ltsc2016'
+    }
+    elseif ("$hostOsVersion" -lt [System.Version]"10.0.20348.0") {
+        # Everything before Windows Server 2022 uses ltsc2019
+        $ltscVersion = 'ltsc2019'
     }
     else {
-        $genericImageNameSetting = $bcContainerHelperConfig.genericImageName
+        # Default is ltsc2022
+        $ltscVersion = 'ltsc2022'
+    }
+
+    if ($filesOnly) {
+        $genericImageNameSetting = $bcContainerHelperConfig.genericImageNameFilesOnly.Replace('{1}', $ltscVersion)
+    }
+    else {
+        $genericImageNameSetting = $bcContainerHelperConfig.genericImageName.Replace('{1}', $ltscVersion)
     }
     $repo = $genericImageNameSetting.Split(':')[0]
     $tag = $genericImageNameSetting.Split(':')[1].Replace('{0}','*')

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Remove support for pre 1.0.2.15 generic images
 Issue 3406 Regression - Set-BcContainerKeyVaultAadAppAndCertificate only worked when running pwsh in container
 Issue 3407 Export-NavContainerDatabasesAsBacpac fails using PS7x (and with tenants on BC24 altogether)
 Issue 3409 Invoke-RestMethod -SkipCertificateCheck for PowerShell 7
+By default use mcr.microsoft.com/businesscentral:ltscXXXX instead of mcr.microsoft.com/businesscentral:10.0.osbuild.osrevision as generic image
 
 6.0.8
 Fix error where Publish-BcNuGetPackageToContainer doesn't work with BC 24


### PR DESCRIPTION
This fix causes everybody to default to ltsc images of Business Central instead of images using specific version numbers.
All Windows versions before Windows Server 2019 will default to **mcr.microsoft.com/businesscentral:ltsc2016** which always is the latest Windows Server 2016 version.
All Windows Server 2019 versions and after (+ before Windows Server 2022) will default to **mcr.microsoft.com/businesscentral:ltsc2019** which always is the latest Windows Server 2019 version
All Windows Server 2022 and after will default to **mcr.microsoft.com/businesscentral:ltsc2022**

This will ensure that people are always using the latest and fully updated (non-vulnerable) generic images.


