### PR TITLE
Customcodecops

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -677,7 +677,7 @@ try {
             $CustomCodeCops | ForEach-Object {
                 $analyzerFileName = $_
                 if ($_ -like 'https://*') {
-                    $analyzerFileName = Join-Path $binPath (Split-Path $_ -Leaf)
+                    $analyzerFileName = Join-Path $binPath "Analyzers/$(Split-Path $_ -Leaf)"
                     Download-File -SourceUrl $_ -destinationFile $analyzerFileName
                 }
                 $alcParameters += @("/analyzer:$analyzerFileName")

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -395,7 +395,7 @@ function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, 
                 New-Item -Path $useFolder -ItemType Directory | Out-Null
             }
             $path = Join-Path $useFolder (Split-Path -Leaf $path)
-            Download-File -url $url -destinationFile $path
+            Download-File -sourceUrl $url -destinationFile $path
         }
         else {
             if (-not [System.IO.Path]::IsPathRooted($path)) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -386,34 +386,23 @@ Param(
     [scriptblock] $InstallMissingDependencies
 )
 
-function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name, [switch] $allowUrl) {
-    if ($path) {
-        if ($path -like 'https://*' -and $allowUrl) {
-            $url = $path
-            $useFolder = Join-Path $baseFolder ".$name"
-            if (!(Test-Path $useFolder)) {
-                New-Item -Path $useFolder -ItemType Directory | Out-Null
-            }
-            $path = Join-Path $useFolder (Split-Path -Leaf $path)
-            Download-File -sourceUrl $url -destinationFile $path
-        }
-        else {
-            if (-not [System.IO.Path]::IsPathRooted($path)) {
-                if (Test-Path -path (Join-Path $baseFolder $path)) {
-                    $path = Join-Path $baseFolder $path -Resolve
-                }
-                else {
-                    $path = Join-Path $baseFolder $path
-                }
+function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name) {
+    if ($path -and $path -notlike 'https://*') {
+        if (-not [System.IO.Path]::IsPathRooted($path)) {
+            if (Test-Path -path (Join-Path $baseFolder $path)) {
+                $path = Join-Path $baseFolder $path -Resolve
             }
             else {
-                if (!(($path -like "$($baseFolder)*") -or (($sharedFolder) -and ($path -like "$($sharedFolder)*")))) {
-                    if ($sharedFolder) {
-                        throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder) or sharedFolder ($sharedFolder)"
-                    }
-                    else {
-                        throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder)"
-                    }
+                $path = Join-Path $baseFolder $path
+            }
+        }
+        else {
+            if (!(($path -like "$($baseFolder)*") -or (($sharedFolder) -and ($path -like "$($sharedFolder)*")))) {
+                if ($sharedFolder) {
+                    throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder) or sharedFolder ($sharedFolder)"
+                }
+                else {
+                    throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder)"
                 }
             }
         }
@@ -524,7 +513,7 @@ if ($customCodeCops                 -is [String]) { $customCodeCops = @($customC
 $appFolders  = @($appFolders  | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "appFolders" } | Where-Object { Test-Path $_ } )
 $testFolders = @($testFolders | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "testFolders" } | Where-Object { Test-Path $_ } )
 $bcptTestFolders = @($bcptTestFolders | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "bcptTestFolders" } | Where-Object { Test-Path $_ } )
-$customCodeCops = @($customCodeCops | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "customCodeCops" -allowUrl } | Where-Object { Test-Path $_ } )
+$customCodeCops = @($customCodeCops | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "customCodeCops" } | Where-Object { $_ -like 'https://*' -or (Test-Path $_) } )
 $buildOutputFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $buildOutputFile -name "buildOutputFile"
 $containerEventLogFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $containerEventLogFile -name "containerEventLogFile"
 $testResultsFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $testResultsFile -name "testResultsFile"

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -386,23 +386,34 @@ Param(
     [scriptblock] $InstallMissingDependencies
 )
 
-function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name) {
+function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name, [switch] $allowUrl) {
     if ($path) {
-        if (-not [System.IO.Path]::IsPathRooted($path)) {
-            if (Test-Path -path (Join-Path $baseFolder $path)) {
-                $path = Join-Path $baseFolder $path -Resolve
+        if ($path -eq 'https://*' -and $allowUrl) {
+            $url = $path
+            $useFolder = Join-Path $baseFolder ".$name"
+            if (!(Test-Path $useFolder)) {
+                New-Item -Path $useFolder -ItemType Directory | Out-Null
             }
-            else {
-                $path = Join-Path $baseFolder $path
-            }
+            $path = Join-Path $useFolder (Split-Path -Leaf $path)
+            Download-File -url $url -destinationFile $path
         }
         else {
-            if (!(($path -like "$($baseFolder)*") -or (($sharedFolder) -and ($path -like "$($sharedFolder)*")))) {
-                if ($sharedFolder) {
-                    throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder) or sharedFolder ($sharedFolder)"
+            if (-not [System.IO.Path]::IsPathRooted($path)) {
+                if (Test-Path -path (Join-Path $baseFolder $path)) {
+                    $path = Join-Path $baseFolder $path -Resolve
                 }
                 else {
-                    throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder)"
+                    $path = Join-Path $baseFolder $path
+                }
+            }
+            else {
+                if (!(($path -like "$($baseFolder)*") -or (($sharedFolder) -and ($path -like "$($sharedFolder)*")))) {
+                    if ($sharedFolder) {
+                        throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder) or sharedFolder ($sharedFolder)"
+                    }
+                    else {
+                        throw "$name is ($path) must be a subfolder to baseFolder ($baseFolder)"
+                    }
                 }
             }
         }
@@ -513,7 +524,7 @@ if ($customCodeCops                 -is [String]) { $customCodeCops = @($customC
 $appFolders  = @($appFolders  | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "appFolders" } | Where-Object { Test-Path $_ } )
 $testFolders = @($testFolders | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "testFolders" } | Where-Object { Test-Path $_ } )
 $bcptTestFolders = @($bcptTestFolders | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "bcptTestFolders" } | Where-Object { Test-Path $_ } )
-$customCodeCops = @($customCodeCops | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "customCodeCops" } | Where-Object { Test-Path $_ } )
+$customCodeCops = @($customCodeCops | ForEach-Object { CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $_ -name "customCodeCops" -allowUrl } | Where-Object { Test-Path $_ } )
 $buildOutputFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $buildOutputFile -name "buildOutputFile"
 $containerEventLogFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $containerEventLogFile -name "containerEventLogFile"
 $testResultsFile = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $testResultsFile -name "testResultsFile"

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -387,6 +387,7 @@ Param(
 )
 
 function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name, [switch] $allowUrl) {
+    Write-Host "$Name : $path"
     if ($path) {
         if ($path -eq 'https://*' -and $allowUrl) {
             $url = $path

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -387,9 +387,8 @@ Param(
 )
 
 function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name, [switch] $allowUrl) {
-    Write-Host "$Name : $path"
     if ($path) {
-        if ($path -eq 'https://*' -and $allowUrl) {
+        if ($path -like 'https://*' -and $allowUrl) {
             $url = $path
             $useFolder = Join-Path $baseFolder ".$name"
             if (!(Test-Path $useFolder)) {

--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -366,7 +366,14 @@ try {
     }
 
     if ($CustomCodeCops.Count -gt 0) {
-        $CustomCodeCops | ForEach-Object { $alcParameters += @("/analyzer:$_") }
+        $CustomCodeCops | ForEach-Object {
+            $analyzerFileName = $_
+            if ($_ -like 'https://*') {
+                $analyzerFileName = Join-Path $binPath (Split-Path $_ -Leaf)
+                Download-File -SourceUrl $_ -destinationFile $analyzerFileName
+            }
+            $alcParameters += @("/analyzer:$analyzerFileName")
+        }
     }
 
     if ($rulesetFile) {

--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -369,7 +369,7 @@ try {
         $CustomCodeCops | ForEach-Object {
             $analyzerFileName = $_
             if ($_ -like 'https://*') {
-                $analyzerFileName = Join-Path $binPath (Split-Path $_ -Leaf)
+                $analyzerFileName = Join-Path $binPath "Analyzers/$(Split-Path $_ -Leaf)"
                 Download-File -SourceUrl $_ -destinationFile $analyzerFileName
             }
             $alcParameters += @("/analyzer:$analyzerFileName")

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 6.0.16
 Issue 3477 Regression: Error: App filenames must be unique
 Issue 3478 New-bccontainer fails on BC24 using option -UseNewDatabase
+Allow CustomCodeCops to be a URL for just-in-time download instead of a file shared with the container
 
 6.0.15
 Issue 3467 Can't create a backup of a container with the Backup-BCContainerDatabases commandlet


### PR DESCRIPTION
Allow CustomCodeCops to be a URL (instead of a file shared with the container)
f.ex. https://github.com/StefanMaron/BusinessCentral.LinterCop/releases/download/v0.30.0/BusinessCentral.LinterCop.current.dll

Remember that some customCodeCops requires you to set vsixFile = latest as well.