### PR TITLE
Use sessions

### DIFF
--- a/BC.HelperFunctions.ps1
+++ b/BC.HelperFunctions.ps1
@@ -15,7 +15,8 @@ function Get-ContainerHelperConfig {
             "genericImageNameFilesOnly" = 'mcr.microsoft.com/businesscentral:{1}-filesonly'
             "usePsSession" = $true
             "usePwshForBc24" = $true
-            "tryWinRmSession" = !$isAdministrator
+            "useSslForWinRm" = $true
+            "tryWinRmSession" = $isPsCore -or !$isAdministrator
             "addTryCatchToScriptBlock" = $true
             "killPsSessionProcess" = $false
             "useVolumes" = $false

--- a/ContainerHandling/Enter-NavContainer.ps1
+++ b/ContainerHandling/Enter-NavContainer.ps1
@@ -19,7 +19,7 @@ function Enter-BcContainer {
 
     Process {
         if ($bcContainerHelperConfig.usePsSession) {
-            $session = Get-BcContainerSession -containerName $containerName -silent -tryWinRmSession
+            $session = Get-BcContainerSession -containerName $containerName -silent
             Enter-PSSession -Session $session
             if ($session.ComputerType -eq 'Container') {
                 Invoke-Command -Session $session -ScriptBlock {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1597,7 +1597,15 @@ if (!$restartingInstance) {
     Add-LocalGroupMember -Group administrators -Member '+$bcContainerHelperConfig.WinRmCredentials.UserName+'
 }
 ') | Add-Content -Path "$myfolder\AdditionalSetup.ps1"
-
+    }
+    else {
+        ('
+if (!$restartingInstance) {
+    Enable-PSRemoting | Out-Null
+    Get-PSSessionConfiguration | Out-null
+    pwsh.exe -Command "Enable-PSRemoting -WarningAction SilentlyContinue | Out-Null; Get-PSSessionConfiguration | Out-Null"
+}
+') | Add-Content -Path "$myfolder\AdditionalSetup.ps1"
     }
     if ($includeCSide) {
         $programFilesFolder = Join-Path $containerFolder "Program Files"


### PR DESCRIPTION
Add PowerShell configurations and PSRemoting when creating containers
Allow standard Container sessions (when host is running PS5 in admin mode) to be to PS5 or PS7 (base on version and usePwshForBC24 flag)
Use WinRm to create a session to a container when running PS7 or non-admin mode.
WinRm session uses HTTPS unless $bccontainerHelperConfig.useSslForWinRm is set to $false
Using HTTP for WinRm requires you to add trustedHosts to the hosts winrm configuration (if not running as administrator)

