### PR TITLE
compatibility with pwsh

### DIFF
--- a/ContainerInfo/Test-NavContainer.ps1
+++ b/ContainerInfo/Test-NavContainer.ps1
@@ -23,7 +23,7 @@ try {
         $id = ""
         $a = "-a"
         if ($doNotIncludeStoppedContainers) {
-            $a = ""
+            $a = $null
         }
 
         $id = docker ps $a --no-trunc --format "{{.ID}}/{{.Names}}" | Where-Object { $containerName -eq $_.split('/')[1] } | ForEach-Object { $_.split('/')[0] }


### PR DESCRIPTION
Using an empty string as parameter not works in pwsh.

**This code fails in PS7.x**
```powershell
$a = ""
docker ps $a
```

**This code works in PS5.x and PS7.x**
```powershell
$a = $null
docker ps $a
```
