### PR TITLE
Fix infinite loop due special character in filename

### DIFF
--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -78,7 +78,7 @@ function RoboCopyFiles {
         RoboCopy "$source" "$destination" "$files" /e /NFL /NDL /NJH /NJS /nc /ns /np /mt /z /nooffload | Out-Null
         Get-ChildItem -Path $source -Filter $files -Recurse | ForEach-Object {
             $destPath = Join-Path $destination $_.FullName.Substring($source.Length)
-            while (!(Test-Path $destPath)) {
+            while (!(Test-Path -literalPath $destPath)) {
                 Write-Host "Waiting for $destPath to be available"
                 Start-Sleep -Seconds 1
             }
@@ -88,7 +88,7 @@ function RoboCopyFiles {
         RoboCopy "$source" "$destination" "$files" /NFL /NDL /NJH /NJS /nc /ns /np /mt /z /nooffload | Out-Null
         Get-ChildItem -Path $source -Filter $files | ForEach-Object {
             $destPath = Join-Path $destination $_.FullName.Substring($source.Length)
-            while (!(Test-Path $destPath)) {
+            while (!(Test-Path -literalPath $destPath)) {
                 Write-Host "Waiting for $destPath to be available"
                 Start-Sleep -Seconds 1
             }


### PR DESCRIPTION
Today, I encountered an infinite loop when creating a new container that required a new docker image. The repeated message in the shell indicated the problem: 

`Waiting for c:\bcartifacts.cache\deaz3r2n.5od\NAVDVD\ModernDev\program files\Microsoft Dynamics NAV\230\AL Development Environment\ALLanguage\[Content_Types].xml to be available`

The file `[Content_Types].xml` contains special characters, causing Test-Path to return $false. By specifying that the path is a literal path, the function returns $true. 