### PR TITLE
Support compilerfolder and online environments

### DIFF
--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -19,7 +19,11 @@ class ClientContext {
     $currentInteraction = $null
 
     ClientContext([string] $serviceUrl, [string] $accessToken, [timespan] $interactionTimeout, [string] $culture, [string] $timezone) {
+        Write-Host $serviceUrl
         Write-Host $accessToken
+        Write-Host $interactionTimeout
+        Write-Host $culture
+        Write-Host $timezone
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::AzureActiveDirectory), (New-Object Microsoft.Dynamics.Framework.UI.Client.TokenCredential -ArgumentList $accessToken), $interactionTimeout, $culture, $timezone)
     }
 

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -78,6 +78,7 @@ class ClientContext {
             if ([ClientContext]::OpenClientContext) {
                 if ([ClientContext]::OpenClientContext.debugMode) {
                     try {
+                        Write-Host "Enumerate forms:"
                         [ClientContext]::OpenClientContext.GetAllForms() | ForEach-Object {
                             $formInfo = [ClientContext]::OpenClientContext.GetFormInfo($_)
                             if ($formInfo) {
@@ -263,7 +264,7 @@ class ClientContext {
                 $formInfo = [ClientContext]::OpenClientContext.GetFormInfo($form)
                 if ($formInfo) {
                     Write-Host -ForegroundColor Yellow "Title: $($formInfo.title)"
-#                    $formInfo.controls | ConvertTo-Json -Depth 99 | Out-Host
+                    $formInfo.controls | ConvertTo-Json -Depth 99 | Out-Host
                 }
             }
         }
@@ -284,7 +285,7 @@ class ClientContext {
         Write-Host "g"
         $form = [ClientContext]::PsTestRunnerCaughtForm
         Write-Host "h"
-        Remove-Variable PsTestRunnerCaughtForm -Scope Global
+        [ClientContext]::PsTestRunnerCaughtForm = $null
         Write-Host "i"
         return $form
     }

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -67,7 +67,7 @@ class ClientContext {
         Write-Host "SET OPENCLIENTCONTEXT"
         [ClientContext]::OpenClientContext = $this
         Write-Host $this.debugMode
-        Write-Host [ClientContext]::OpenClientContext.debugMode
+        Write-Host ([ClientContext]::OpenClientContext.debugMode)
         $clientSessionParameters = New-Object Microsoft.Dynamics.Framework.UI.Client.ClientSessionParameters
         $clientSessionParameters.CultureId = $this.culture
         $clientSessionParameters.UICultureId = $this.culture

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -19,6 +19,7 @@ class ClientContext {
     $currentInteraction = $null
 
     ClientContext([string] $serviceUrl, [string] $accessToken, [timespan] $interactionTimeout, [string] $culture, [string] $timezone) {
+        Write-Host $accessToken
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::AzureActiveDirectory), (New-Object Microsoft.Dynamics.Framework.UI.Client.TokenCredential -ArgumentList $accessToken), $interactionTimeout, $culture, $timezone)
     }
 

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -31,11 +31,11 @@ class ClientContext {
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::AzureActiveDirectory), (New-Object Microsoft.Dynamics.Framework.UI.Client.TokenCredential -ArgumentList $accessToken), ([timespan]::FromMinutes(10)), 'en-US', '')
     }
 
-    ClientContext([string] $serviceUrl, [pscredential] $credential, [timespan] $interactionTimeout, [string] $culture, [string] $timezone) {
+    ClientContext([string] $serviceUrl, [System.Management.Automation.PSCredential] $credential, [timespan] $interactionTimeout, [string] $culture, [string] $timezone) {
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::UserNamePassword), (New-Object System.Net.NetworkCredential -ArgumentList $credential.UserName, $credential.Password), $interactionTimeout, $culture, $timezone)
     }
 
-    ClientContext([string] $serviceUrl, [pscredential] $credential) {
+    ClientContext([string] $serviceUrl, [System.Management.Automation.PSCredential] $credential) {
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::UserNamePassword), (New-Object System.Net.NetworkCredential -ArgumentList $credential.UserName, $credential.Password), ([timespan]::FromMinutes(10)), 'en-US', '')
     }
 

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -12,7 +12,7 @@ class ClientContext {
     $culture = ""
     $timezone = ""
     $caughtForm = $null
-    $debugMode = $true
+    $debugMode = $false
     $addressUri = $null
     $interactionStart = $null
     $currentInteraction = $null

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -1,5 +1,4 @@
-﻿#requires -Version 5.0
-Param(
+﻿Param(
     [Parameter(Mandatory=$true)]
     [string] $clientDllPath
 )
@@ -19,11 +18,6 @@ class ClientContext {
     $currentInteraction = $null
 
     ClientContext([string] $serviceUrl, [string] $accessToken, [timespan] $interactionTimeout, [string] $culture, [string] $timezone) {
-        Write-Host $serviceUrl
-        Write-Host $accessToken
-        Write-Host $interactionTimeout
-        Write-Host $culture
-        Write-Host $timezone
         $this.Initialize($serviceUrl, ([Microsoft.Dynamics.Framework.UI.Client.AuthenticationScheme]::AzureActiveDirectory), (New-Object Microsoft.Dynamics.Framework.UI.Client.TokenCredential -ArgumentList $accessToken), $interactionTimeout, $culture, $timezone)
     }
 
@@ -69,10 +63,7 @@ class ClientContext {
     }
 
     OpenSession() {
-        Write-Host "SET OPENCLIENTCONTEXT"
         [ClientContext]::OpenClientContext = $this
-        Write-Host $this.debugMode
-        Write-Host ([ClientContext]::OpenClientContext.debugMode)
         $clientSessionParameters = New-Object Microsoft.Dynamics.Framework.UI.Client.ClientSessionParameters
         $clientSessionParameters.CultureId = $this.culture
         $clientSessionParameters.UICultureId = $this.culture
@@ -83,13 +74,12 @@ class ClientContext {
             if ([ClientContext]::OpenClientContext) {
                 if ([ClientContext]::OpenClientContext.debugMode) {
                     try {
-                        Write-Host "Enumerate forms:"
                         [ClientContext]::OpenClientContext.GetAllForms() | ForEach-Object {
                             $formInfo = [ClientContext]::OpenClientContext.GetFormInfo($_)
                             if ($formInfo) {
                                 Write-Host -ForegroundColor Yellow "Title: $($formInfo.title)"
                                 Write-Host -ForegroundColor Yellow "Title: $($formInfo.identifier)"
-                                $formInfo.controls | ConvertTo-Json -Depth 99 | Out-Host
+#                                $formInfo.controls | ConvertTo-Json -Depth 99 | Out-Host
                             }
                         }
                     }
@@ -207,11 +197,8 @@ class ClientContext {
             }
         })
 
-        Write-Host "Open Session"
         $this.clientSession.OpenSessionAsync($clientSessionParameters)
-        Write-Host "Await Ready"
         $this.Awaitstate([Microsoft.Dynamics.Framework.UI.Client.ClientSessionState]::Ready)
-        Write-Host "Ready"
     }
     #
     
@@ -274,24 +261,15 @@ class ClientContext {
             }
         }
         try {
-            Write-Host "a"
             $this.InvokeInteraction($interaction)
-            Write-Host "b"
             if (!([ClientContext]::PsTestRunnerCaughtForm)) {
-                Write-Host "c"
                 $this.CloseAllWarningForms()
-                Write-Host "d"
             }
-            Write-Host "e"
         } finally {
-            Write-Host "f"
             Unregister-Event -SourceIdentifier $formToShowEvent.Name
         }
-        Write-Host "g"
         $form = [ClientContext]::PsTestRunnerCaughtForm
-        Write-Host "h"
         [ClientContext]::PsTestRunnerCaughtForm = $null
-        Write-Host "i"
         return $form
     }
     

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -195,9 +195,12 @@ class ClientContext {
                 }
             }
         })
-    
+
+        Write-Host "Open Session"
         $this.clientSession.OpenSessionAsync($clientSessionParameters)
+        Write-Host "Await Ready"
         $this.Awaitstate([Microsoft.Dynamics.Framework.UI.Client.ClientSessionState]::Ready)
+        Write-Host "Ready"
     }
     #
     

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -11,7 +11,7 @@ class ClientContext {
     $culture = ""
     $timezone = ""
     $caughtForm = $null
-    $debugMode = $false
+    $debugMode = $true
     $addressUri = $null
     $interactionStart = $null
     $currentInteraction = $null

--- a/AppHandling/ClientContext.ps1
+++ b/AppHandling/ClientContext.ps1
@@ -263,15 +263,24 @@ class ClientContext {
             }
         }
         try {
+            Write-Host "a"
             $this.InvokeInteraction($interaction)
+            Write-Host "b"
             if (!($Global:PsTestRunnerCaughtForm)) {
+                Write-Host "c"
                 $this.CloseAllWarningForms()
+                Write-Host "d"
             }
+            Write-Host "e"
         } finally {
+            Write-Host "f"
             Unregister-Event -SourceIdentifier $formToShowEvent.Name
         }
+        Write-Host "g"
         $form = $Global:PsTestRunnerCaughtForm
+        Write-Host "h"
         Remove-Variable PsTestRunnerCaughtForm -Scope Global
+        Write-Host "i"
         return $form
     }
     

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -427,7 +427,7 @@ try {
                 throw "You need to specify credentials when you are not using Windows Authentication"
             }
 
-            $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
+            $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
             $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
             $base64 = [System.Convert]::ToBase64String($bytes)
             $basicAuthValue = "Basic $base64"

--- a/AppHandling/Get-NavContainerApp.ps1
+++ b/AppHandling/Get-NavContainerApp.ps1
@@ -76,7 +76,7 @@ try {
             throw "You need to specify credentials when you are not using Windows Authentication"
         }
         
-        $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
+        $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
         $base64 = [System.Convert]::ToBase64String($bytes)
         $basicAuthValue = "Basic $base64"

--- a/AppHandling/Get-TestsFromNavContainer.ps1
+++ b/AppHandling/Get-TestsFromNavContainer.ps1
@@ -182,9 +182,9 @@ try {
 
     $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testCodeunit, [string] $testCodeunitRange, [string] $PsTestFunctionsPath, [string] $ClientContextPath, $testPage, $version, $culture, $timezone, $debugMode, $ignoreGroups, $usePublicWebBaseUrl, $useUrl, $extensionId, $disabledtests)
     
-        $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+        $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
         if (!(Test-Path $newtonSoftDllPath)) {
-            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
         }
         $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
         $clientDllPath = "C:\Test Assemblies\Microsoft.Dynamics.Framework.UI.Client.dll"

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -23,7 +23,7 @@ function New-ClientContext {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $auth='NavUserPassword',
         [Parameter(Mandatory=$false)]
-        [pscredential] $credential,
+        [System.Management.Automation.PSCredential] $credential,
         [timespan] $interactionTimeout = [timespan]::FromMinutes(10),
         [string] $culture = "en-US",
         [string] $timezone = "",
@@ -248,7 +248,7 @@ function CollectCoverageResults {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $AutorizationType = $script:DefaultAuthorizationType,
         [Parameter(Mandatory=$false)]
-        [pscredential] $Credential,
+        [System.Management.Automation.PSCredential] $Credential,
         [Parameter(Mandatory=$true)]
         [string] $ServiceUrl,
         [string] $CodeCoverageFilePrefix
@@ -292,7 +292,7 @@ function SaveCodeCoverageMap {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $AutorizationType = $script:DefaultAuthorizationType,
         [Parameter(Mandatory=$false)]
-        [pscredential] $Credential,
+        [System.Management.Automation.PSCredential] $Credential,
         [Parameter(Mandatory=$true)]
         [string] $ServiceUrl
     )

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -570,6 +570,9 @@ function Run-Tests {
         Write-Host "Run-Tests, open page $testpage"
     }
 
+    Write-Host "Open page 21"
+    $form = $clientContext.OpenForm(21)
+    Write-Host "Open Page $testPage"
     $form = $clientContext.OpenForm($testPage)
     if (!($form)) {
         throw "Cannot open page $testPage. You might need to import the test toolkit to the container and/or remove the folder $PSScriptRoot and retry. You might also have URL or Company name wrong."

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -47,6 +47,8 @@ function New-ClientContext {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
         $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password))
+        Write-Host $accessToken.GetType()
+        Write-Host $accessToken.Length
         $clientContext = [ClientContext]::new($serviceUrl, $accessToken, $interactionTimeout, $culture, $timezone)
     }
     else {

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -46,7 +46,9 @@ function New-ClientContext {
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
-        $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password))
+        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)
+        $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+        [Runtime.InteropServices.Marshal]::FreeBSTR($bstr)
         Write-Host $accessToken.GetType()
         Write-Host $accessToken.Length
         $clientContext = [ClientContext]::new($serviceUrl, $accessToken, $interactionTimeout, $culture, $timezone)

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -23,7 +23,7 @@ function New-ClientContext {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $auth='NavUserPassword',
         [Parameter(Mandatory=$false)]
-        [System.Management.Automation.PSCredential] $credential,
+        [pscredential] $credential,
         [timespan] $interactionTimeout = [timespan]::FromMinutes(10),
         [string] $culture = "en-US",
         [string] $timezone = "",
@@ -40,6 +40,7 @@ function New-ClientContext {
         $clientContext = [ClientContext]::new($serviceUrl, $credential, $interactionTimeout, $culture, $timezone)
     }
     elseif ($auth -eq "AAD") {
+
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
@@ -240,7 +241,7 @@ function CollectCoverageResults {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $AutorizationType = $script:DefaultAuthorizationType,
         [Parameter(Mandatory=$false)]
-        [System.Management.Automation.PSCredential] $Credential,
+        [pscredential] $Credential,
         [Parameter(Mandatory=$true)]
         [string] $ServiceUrl,
         [string] $CodeCoverageFilePrefix
@@ -284,7 +285,7 @@ function SaveCodeCoverageMap {
         [ValidateSet('Windows','NavUserPassword','AAD')]
         [string] $AutorizationType = $script:DefaultAuthorizationType,
         [Parameter(Mandatory=$false)]
-        [System.Management.Automation.PSCredential] $Credential,
+        [pscredential] $Credential,
         [Parameter(Mandatory=$true)]
         [string] $ServiceUrl
     )

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -46,9 +46,7 @@ function New-ClientContext {
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
-        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)
-        $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-        [Runtime.InteropServices.Marshal]::FreeBSTR($bstr)
+        $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password))
         Write-Host $accessToken.GetType()
         Write-Host $accessToken.Length
         $clientContext = [ClientContext]::new($serviceUrl, $accessToken, $interactionTimeout, $culture, $timezone)

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -31,31 +31,25 @@ function New-ClientContext {
     )
 
     if ($auth -eq "Windows") {
-        Write-Host "Windows"
         $clientContext = [ClientContext]::new($serviceUrl, $interactionTimeout, $culture, $timezone)
     }
     elseif ($auth -eq "NavUserPassword") {
-        Write-Host "NavUserPassword"
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials if using NavUserPassword authentication"
         }
         $clientContext = [ClientContext]::new($serviceUrl, $credential, $interactionTimeout, $culture, $timezone)
     }
     elseif ($auth -eq "AAD") {
-        Write-Host "AAD"
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
         $accessToken = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password))
-        Write-Host $accessToken.GetType()
-        Write-Host $accessToken.Length
         $clientContext = [ClientContext]::new($serviceUrl, $accessToken, $interactionTimeout, $culture, $timezone)
     }
     else {
         throw "Unsupported authentication setting"
     }
     if ($clientContext) {
-        Write-Host "set DebugMode"
         $clientContext.debugMode = $debugMode
     }
     return $clientContext

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -726,6 +726,13 @@ function Run-Tests {
                 $JunitTestSuiteProperties = $JUnitDoc.CreateElement("properties")
                 $JUnitTestSuite.AppendChild($JunitTestSuiteProperties) | Out-Null
 
+                if ($extensionid) {
+                    $property = $JUnitDoc.CreateElement("property")
+                    $property.SetAttribute("name","extensionid")
+                    $property.SetAttribute("value", $extensionId)
+                    $JunitTestSuiteProperties.AppendChild($property) | Out-Null
+                }
+
                 if ($process) {
                     $property = $JUnitDoc.CreateElement("property")
                     $property.SetAttribute("name","processinfo.start")
@@ -733,11 +740,6 @@ function Run-Tests {
                     $JunitTestSuiteProperties.AppendChild($property) | Out-Null
 
                     if ($extensionid) {
-                        $property = $JUnitDoc.CreateElement("property")
-                        $property.SetAttribute("name","extensionid")
-                        $property.SetAttribute("value", $extensionId)
-                        $JunitTestSuiteProperties.AppendChild($property) | Out-Null
-
                         $appname = "$(Get-NavAppInfo -ServerInstance $serverInstance | Where-Object { "$($_.AppId)" -eq $extensionId } | ForEach-Object { $_.Name })"
                         if ($appname) {
                             $property = $JUnitDoc.CreateElement("property")

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -31,16 +31,18 @@ function New-ClientContext {
     )
 
     if ($auth -eq "Windows") {
+        Write-Host "Windows"
         $clientContext = [ClientContext]::new($serviceUrl, $interactionTimeout, $culture, $timezone)
     }
     elseif ($auth -eq "NavUserPassword") {
+        Write-Host "NavUserPassword"
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials if using NavUserPassword authentication"
         }
         $clientContext = [ClientContext]::new($serviceUrl, $credential, $interactionTimeout, $culture, $timezone)
     }
     elseif ($auth -eq "AAD") {
-
+        Write-Host "AAD"
         if ($Credential -eq $null -or $credential -eq [System.Management.Automation.PSCredential]::Empty) {
             throw "You need to specify credentials (Username and AccessToken) if using AAD authentication"
         }
@@ -51,6 +53,7 @@ function New-ClientContext {
         throw "Unsupported authentication setting"
     }
     if ($clientContext) {
+        Write-Host "set DebugMode"
         $clientContext.debugMode = $debugMode
     }
     return $clientContext
@@ -570,9 +573,6 @@ function Run-Tests {
         Write-Host "Run-Tests, open page $testpage"
     }
 
-    Write-Host "Open page 21"
-    $form = $clientContext.OpenForm(21)
-    Write-Host "Open Page $testPage"
     $form = $clientContext.OpenForm($testPage)
     if (!($form)) {
         throw "Cannot open page $testPage. You might need to import the test toolkit to the container and/or remove the folder $PSScriptRoot and retry. You might also have URL or Company name wrong."

--- a/AppHandling/Publish-NavContainerApp.ps1
+++ b/AppHandling/Publish-NavContainerApp.ps1
@@ -233,7 +233,7 @@ try {
                         if (!($credential)) {
                             throw "You need to specify credentials when you are not using Windows Authentication"
                         }
-                        $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
+                        $pair = ("$($Credential.UserName):"+[System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($credential.Password)))
                         $bytes = [System.Text.Encoding]::ASCII.GetBytes($pair)
                         $base64 = [System.Convert]::ToBase64String($bytes)
                         $HttpClient.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Basic", $base64);

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -2654,7 +2654,11 @@ finally {
     $progressPreference = $prevProgressPreference
 }
 
-if (!$keepContainer) {
+if ($useCompilerFolder -and $compilerFolder) {
+    Remove-BcCompilerFolder -compilerFolder $compilerFolder
+}
+
+if ($createContainer -and !$keepContainer) {
 if ($gitHubActions) { Write-Host "::group::Removing container" }
 if (!($err)) {
 Write-Host -ForegroundColor Yellow @'
@@ -2670,9 +2674,6 @@ Write-Host -ForegroundColor Yellow @'
 }
 Measure-Command {
 
-    if ($useCompilerFolder -and $compilerFolder) {
-        Remove-BcCompilerFolder -compilerFolder $compilerFolder
-    }
     if (!$doNotPublishApps) {
         if (!$filesOnly -and $containerEventLogFile) {
             try {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -255,6 +255,8 @@
   Override function parameter for Get-BestGenericImageName
  .Parameter GetBcContainerEventLog
   Override function parameter for Get-BcContainerEventLog
+ .Parameter GetBcPublishedApps
+  Override function parameter for Get-BcPublishedApps
  .Parameter InstallMissingDependencies
   Override function parameter for Installing missing dependencies
  .Example
@@ -383,6 +385,7 @@ Param(
     [scriptblock] $RemoveBcContainer,
     [scriptblock] $GetBestGenericImageName,
     [scriptblock] $GetBcContainerEventLog,
+    [scriptblock] $GetBcPublishedApps,
     [scriptblock] $InstallMissingDependencies
 )
 
@@ -541,6 +544,12 @@ if ($bcptTestFolders) {
     }
 }
 
+if ($GetBcPublishedApps) {
+    Write-Host -ForegroundColor Yellow "GetBcPublishedApps override"; Write-Host $GetBcPublishedApps.ToString()
+}
+else {
+    $GetBcPublishedApps = { Param([Hashtable]$parameters) Get-BcPublishedApps @parameters }
+}
 $artifactUrl = ""
 $filesOnly = $false
 if ($bcAuthContext) {
@@ -554,12 +563,18 @@ if ($bcAuthContext) {
         Write-Host -ForegroundColor Yellow "Uninstalling removed apps from online environments are not supported"
         $uninstallRemovedApps = $false
     }
-    $bcAuthContext = Renew-BcAuthContext -bcAuthContext $bcAuthContext
-    $bcEnvironment = Get-BcEnvironments -bcAuthContext $bcAuthContext | Where-Object { $_.name -eq $environment -and $_.type -eq "Sandbox" }
-    if (!($bcEnvironment)) {
-        throw "Environment $environment doesn't exist in the current context or it is not a Sandbox environment."
+    if ($environment -notlike ('https://*')) {
+        $bcAuthContext = Renew-BcAuthContext -bcAuthContext $bcAuthContext
+        $bcEnvironment = Get-BcEnvironments -bcAuthContext $bcAuthContext | Where-Object { $_.name -eq $environment -and $_.type -eq "Sandbox" }
+        if (!($bcEnvironment)) {
+            throw "Environment $environment doesn't exist in the current context or it is not a Sandbox environment."
+        }
     }
-    $bcBaseApp = Get-BcPublishedApps -bcAuthContext $bcauthcontext -environment $environment | Where-Object { $_.Name -eq "Base Application" -and $_.state -eq "installed" }
+    $parameters = @{
+        bcAuthContext = $bcAuthContext
+        environment = $environment
+    }
+    $bcBaseApp = Invoke-Command -ScriptBlock $GetBcPublishedApps -ArgumentList $Parameters | Where-Object { $_.Name -eq "Base Application" -and $_.state -eq "installed" }
     $artifactUrl = Get-BCArtifactUrl -type Sandbox -country $bcEnvironment.countryCode -version $bcBaseApp.Version -select Closest
     $filesOnly = $true
 }
@@ -748,14 +763,16 @@ Write-Host -ForegroundColor Yellow "Custom CodeCops"
 if ($customCodeCops) { $customCodeCops | ForEach-Object { Write-Host "- $_" } } else { Write-Host "- None" }
 
 $vsixFile = DetermineVsixFile -vsixFile $vsixFile
-
 $compilerFolder = ''
+$createContainer = $true
 
 if ($useCompilerFolder) {
     # We are using CompilerFolder, no need for a filesOnly Container
     # If we are to create a container, it is for publishing and testing
     $filesOnly = $false
     $updateLaunchJson = ''
+    $createContainer = !($doNotPublishApps -or ($bcAuthContext -and $environment))
+    if (!$createContainer) { $containerName = ''}
 }
 elseif ($doNotPublishApps) {
     # We are not using CompilerFolder, but we are not publishing apps either
@@ -908,7 +925,7 @@ $signApps = ($codeSignCertPfxFile -ne "")
 
 Measure-Command {
 
-if ( $artifactUrl -and !$reUseContainer -and !$doNotPublishApps -and !$filesOnly) {
+if ( $artifactUrl -and !$reUseContainer -and $createContainer) {
 if ($gitHubActions) { Write-Host "::group::Pulling generic image" }
 Measure-Command {
 Write-Host -ForegroundColor Yellow @'
@@ -948,19 +965,36 @@ try {
 $testCountry = $_.Trim()
 $testToolkitInstalled = $false
 
-if ($gitHubActions) { Write-Host "::group::Creating container" }
-Write-Host -ForegroundColor Yellow @'
+if ($useCompilerFolder) {
+    if ($gitHubActions) { Write-Host "::group::Creating CompilerFolder" }
+    Write-Host -ForegroundColor Yellow @'
 
-   _____                _   _                               _        _
-  / ____|              | | (_)                             | |      (_)
- | |     _ __ ___  __ _| |_ _ _ __   __ _    ___ ___  _ __ | |_ __ _ _ _ __   ___ _ __
- | |    | '__/ _ \/ _` | __| | '_ \ / _` |  / __/ _ \| '_ \| __/ _` | | '_ \ / _ \ '__|
- | |____| | |  __/ (_| | |_| | | | | (_| | | (__ (_) | | | | |_ (_| | | | | |  __/ |
-  \_____|_|  \___|\__,_|\__|_|_| |_|\__, |  \___\___/|_| |_|\__\__,_|_|_| |_|\___|_|
+   _____                _   _                _____                      _ _           ______    _     _
+  / ____|              | | (_)              / ____|                    (_) |         |  ____|  | |   | |
+ | |     _ __ ___  __ _| |_ _ _ __   __ _  | |     ___  _ __ ___  _ __  _| | ___ _ __| |__ ___ | | __| | ___ _ __
+ | |    | '__/ _ \/ _` | __| | '_ \ / _` | | |    / _ \| '_ ` _ \| '_ \| | |/ _ \ '__|  __/ _ \| |/ _` |/ _ \ '__|
+ | |____| | |  __/ (_| | |_| | | | | (_| | | |___| (_) | | | | | | |_) | | |  __/ |  | | | (_) | | (_| |  __/ |
+  \_____|_|  \___|\__,_|\__|_|_| |_|\__, |  \_____\___/|_| |_| |_| .__/|_|_|\___|_|  |_|  \___/|_|\__,_|\___|_|
+                                     __/ |                       | |
+                                    |___/                        |_|
+
+'@
+}
+else {
+    if ($gitHubActions) { Write-Host "::group::Creating container" }
+    Write-Host -ForegroundColor Yellow @'
+
+   _____                _   _                _____            _        _
+  / ____|              | | (_)              / ____|          | |      (_)
+ | |     _ __ ___  __ _| |_ _ _ __   __ _  | |     ___  _ __ | |_ __ _ _ _ __   ___ _ __
+ | |    | '__/ _ \/ _` | __| | '_ \ / _` | | |    / _ \| '_ \| __/ _` | | '_ \ / _ \ '__|
+ | |____| | |  __/ (_| | |_| | | | | (_| | | |___| (_) | | | | || (_| | | | | |  __/ |
+  \_____|_|  \___|\__,_|\__|_|_| |_|\__, |  \_____\___/|_| |_|\__\__,_|_|_| |_|\___|_|
                                      __/ |
                                     |___/
 
 '@
+}
 
 Measure-Command {
 
@@ -983,7 +1017,7 @@ Measure-Command {
             -containerName $containerName
         Write-Host "CompilerFolder $compilerFolder created"
     }
-    if ($filesOnly -or !$doNotPublishApps) {
+    if ($createContainer -and ($filesOnly -or !$doNotPublishApps)) {
         # If we are going to build using a filesOnly container or we are going to publish apps, we need a container
         if (Test-BcContainer -containerName $containerName) {
             if ($bcAuthContext) {
@@ -1035,7 +1069,7 @@ Measure-Command {
             }
             Invoke-Command -ScriptBlock $NewBcContainer -ArgumentList $Parameters
 
-            if (-not $bcAuthContext) {
+            if ($createContainer -and -not $bcAuthContext) {
                 if ($keyVaultCertPfxFile -and $KeyVaultClientId -and $keyVaultCertPfxPassword) {
                     $Parameters = @{
                         "containerName" = $containerName
@@ -1329,6 +1363,7 @@ Measure-Command {
     Write-Host -ForegroundColor Yellow "Importing Test Toolkit for additional country $testCountry"
     $Parameters = @{
         "containerName" = $containerName
+        "compilerFolder" = $compilerFolder
         "includeTestLibrariesOnly" = $installTestLibraries
         "includeTestFrameworkOnly" = !$installTestLibraries -and ($installTestFramework -or $installPerformanceToolkit)
         "includeTestRunnerOnly" = !$installTestLibraries -and !$installTestFramework -and ($installTestRunner -or $installPerformanceToolkit)
@@ -1508,6 +1543,7 @@ Measure-Command {
         $measureText = ", test apps and importing test toolkit"
         $Parameters = @{
             "containerName" = $containerName
+            "compilerFolder" = $compilerFolder
             "includeTestLibrariesOnly" = $installTestLibraries
             "includeTestFrameworkOnly" = !$installTestLibraries -and ($installTestFramework -or $installPerformanceToolkit)
             "includeTestRunnerOnly" = !$installTestLibraries -and !$installTestFramework -and ($installTestRunner -or $installPerformanceToolkit)
@@ -1654,7 +1690,7 @@ Write-Host -ForegroundColor Yellow @'
     $Parameters = @{ }
     $CopParameters = @{ }
 
-    if ($bcAuthContext) {
+    if ($bcAuthContext -and !$useCompilerFolder) {
         $Parameters += @{
             "bcAuthContext" = $bcAuthContext
             "environment" = $environment
@@ -2433,6 +2469,7 @@ $testAppIds.Keys | ForEach-Object {
     }
     $Parameters = @{
         "containerName" = $containerName
+        "compilerFolder" = $compilerFolder
         "tenant" = $tenant
         "credential" = $credential
         "companyName" = $companyName
@@ -2461,6 +2498,7 @@ $testAppIds.Keys | ForEach-Object {
         $Parameters += @{
             "bcAuthContext" = $bcAuthContext
             "environment" = $environment
+            "ConnectFromHost" = !$createContainer
         }
     }
 

--- a/AppHandling/Run-ConnectionTestToNavContainer.ps1
+++ b/AppHandling/Run-ConnectionTestToNavContainer.ps1
@@ -135,15 +135,15 @@ try {
     }
 
     if ($connectFromHost) {
-        $newtonSoftDllPath = Join-Path $PsTestToolFolder "NewtonSoft.json.dll"
+        $newtonSoftDllPath = Join-Path $PsTestToolFolder "Newtonsoft.Json.dll"
         $clientDllPath = Join-Path $PsTestToolFolder "Microsoft.Dynamics.Framework.UI.Client.dll"
     
         Invoke-ScriptInBcContainer -containerName $containerName { Param([string] $myNewtonSoftDllPath, [string] $myClientDllPath)
         
             if (!(Test-Path $myNewtonSoftDllPath)) {
-                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
                 if (!(Test-Path $newtonSoftDllPath)) {
-                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
                 }
                 $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
                 Copy-Item -Path $newtonSoftDllPath -Destination $myNewtonSoftDllPath
@@ -202,9 +202,9 @@ try {
 
         $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [timespan] $interactionTimeout, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl)
     
-            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
             if (!(Test-Path $newtonSoftDllPath)) {
-                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
             }
             $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
             $clientDllPath = "C:\Test Assemblies\Microsoft.Dynamics.Framework.UI.Client.dll"

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -95,9 +95,9 @@ function Run-TestsInBcContainer {
         [Parameter(Mandatory=$false)]
         [string] $profile = "",
         [Parameter(Mandatory=$false)]
-        [System.Management.Automation.PSCredential] $credential = $null,
+        [PSCredential] $credential = $null,
         [Parameter(Mandatory=$false)]
-        [System.Management.Automation.PSCredential] $sqlCredential = $credential,
+        [PSCredential] $sqlCredential = $credential,
         [Parameter(Mandatory=$false)]
         [string] $accessToken = "",
         [Parameter(Mandatory=$false)]
@@ -260,8 +260,8 @@ try {
 
     if ($bcAuthContext -and ($environment -notlike 'https://*')) {
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
-        $accessToken = $bcAuthContext.AccessToken
-        $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+        $accessToken = $bcAuthContext.accessToken
+        $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
 
     $PsTestFunctionsPath = Join-Path $PsTestToolFolder "PsTestFunctions.ps1"
@@ -345,7 +345,7 @@ try {
     
                 if ($accessToken) {
                     $clientServicesCredentialType = "AAD"
-                    $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+                    $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         
                 if ($companyName) {
@@ -453,7 +453,7 @@ try {
             
                     if ($accessToken) {
                         $clientServicesCredentialType = "AAD"
-                        $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+                        $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                     }
                     elseif ($clientServicesCredentialType -eq "Windows") {
                         $windowsUserName = whoami

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -347,6 +347,8 @@ try {
                 if ($accessToken) {
                     Write-Host "ACCESSTOKEN"
                     $clientServicesCredentialType = "AAD"
+                    Write-Host $credential.UserName
+                    Write-Host "$accessToken".Substring(5)
                     $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -262,6 +262,7 @@ try {
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
         $accessToken = $bcAuthContext.AccessToken
         Write-Host $accessToken.GetType().FullName
+        Write-Host $accessToken
         Write-Host $bcAuthContext.upn
         $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -144,6 +144,7 @@ $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -paramet
 try {
 
     if ($containerName) {
+        Write-Host "CONTAINERNAME"
         $customConfig = Get-BcContainerServerConfiguration -ContainerName $containerName
         $navversion = Get-BcContainerNavversion -containerOrImageName $containerName
         $version = [System.Version]($navversion.split('-')[0])
@@ -151,6 +152,7 @@ try {
 
     }
     elseif ($compilerFolder) {
+        Write-Host "COMPILERFOLDER"
         $customConfig = $null
         $symbolsFolder = Join-Path $compilerFolder "symbols"
         $baseAppInfo = Get-AppJsonFromAppFile -appFile (Get-ChildItem -Path $symbolsFolder -Filter 'Microsoft_Base Application_*.*.*.*.app').FullName
@@ -256,8 +258,10 @@ try {
     }
 
     if ($bcAuthContext -and ($environment -notlike 'https://*')) {
+        Write-Host "RENEW AUTHCONTEXT"
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
-        $accessToken = $bcAuthContext.accessToken
+        $accessToken = $bcAuthContext.AccessToken
+        Write-Host $bcAuthContext.upn
         $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
 
@@ -341,6 +345,7 @@ try {
                 $serviceUrl = "$publicWebBaseUrl/cs?tenant=$tenant"
     
                 if ($accessToken) {
+                    Write-Host "ACCESSTOKEN"
                     $clientServicesCredentialType = "AAD"
                     $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -144,7 +144,7 @@ $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -paramet
 try {
 
     if ($containerName) {
-        Write-Host "CONTAINERNAME"
+        Write-Host "Using Container"
         $customConfig = Get-BcContainerServerConfiguration -ContainerName $containerName
         $navversion = Get-BcContainerNavversion -containerOrImageName $containerName
         $version = [System.Version]($navversion.split('-')[0])
@@ -152,7 +152,7 @@ try {
 
     }
     elseif ($compilerFolder) {
-        Write-Host "COMPILERFOLDER"
+        Write-Host "Using CompilerFolder"
         $customConfig = $null
         $symbolsFolder = Join-Path $compilerFolder "symbols"
         $baseAppInfo = Get-AppJsonFromAppFile -appFile (Get-ChildItem -Path $symbolsFolder -Filter 'Microsoft_Base Application_*.*.*.*.app').FullName
@@ -195,6 +195,7 @@ try {
         $useUrl = $useUrl.Split('?')[0]
         $dict = [System.Web.HttpUtility]::ParseQueryString($uri.Query)
         if ($dict['tenant']) { $tenant = $dict['tenant'] }
+        if ($dict['testpage']) { $testpage = [int]$dict['testpage'] }
     }
     else {
         $clientServicesCredentialType = $customConfig.ClientServicesCredentialType

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -169,6 +169,14 @@ try {
     if ($bcAuthContext -and $environment) {
         if ($environment -like 'https://*') {
             $useUrl = $environment
+            if ($bcAuthContext.ContainsKey('Username') -and $bcAuthContext.ContainsKey('Password')) {
+                $credential = New-Object pscredential $bcAuthContext.Username, $bcAuthContext.Password
+                $clientServicesCredentialType = "NavUserPassword"
+            }
+            if ($bcAuthContext.ContainsKey('ClientServicesCredentialType')) {
+                $clientServicesCredentialType = $bcAuthContext.ClientServicesCredentialType
+            }
+            $testPage = 130455
         }
         else {
             $response = Invoke-RestMethod -Method Get -Uri "$($bcContainerHelperConfig.baseUrl.TrimEnd('/'))/$($bcAuthContext.tenantID)/$environment/deployment/url"
@@ -247,7 +255,7 @@ try {
         } -argumentList $interactionTimeout.ToString()
     }
 
-    if ($bcAuthContext) {
+    if ($bcAuthContext -and ($environment -notlike 'https://*')) {
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
         $accessToken = $bcAuthContext.accessToken
         $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -310,16 +310,16 @@ try {
                 if ($PSVersionTable.PSVersion.Major -lt 7) {
                     throw "Using ConnectFromHost requires PowerShell 7"
                 }
-                $newtonSoftDllPath = Join-Path $PsTestToolFolder "NewtonSoft.json.dll"
+                $newtonSoftDllPath = Join-Path $PsTestToolFolder "Newtonsoft.Json.dll"
                 $clientDllPath = Join-Path $PsTestToolFolder "Microsoft.Dynamics.Framework.UI.Client.dll"
                 if ($containerName) {
                     if (!((Test-Path $newtonSoftDllPath) -and (Test-Path $clientDllPath))) {
                         Invoke-ScriptInBcContainer -containerName $containerName { Param([string] $myNewtonSoftDllPath, [string] $myClientDllPath)
                     
                             if (!(Test-Path $myNewtonSoftDllPath)) {
-                                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+                                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
                                 if (!(Test-Path $newtonSoftDllPath)) {
-                                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+                                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
                                 }
                                 $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
                                 Copy-Item -Path $newtonSoftDllPath -Destination $myNewtonSoftDllPath
@@ -426,9 +426,9 @@ try {
 
                 $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testGroup, [string] $testCodeunit, [string] $testCodeunitRange, [string] $testFunction, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [string] $XUnitResultFileName, [bool] $AppendToXUnitResultFile, [string] $JUnitResultFileName, [bool] $AppendToJUnitResultFile, [bool] $ReRun, [string] $AzureDevOps, [string] $GitHubActions, [bool] $detailed, [timespan] $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests)
     
-                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+                    $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
                     if (!(Test-Path $newtonSoftDllPath)) {
-                        $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+                        $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
                     }
                     $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
                     $clientDllPath = "C:\Test Assemblies\Microsoft.Dynamics.Framework.UI.Client.dll"

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -261,6 +261,7 @@ try {
         Write-Host "RENEW AUTHCONTEXT"
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
         $accessToken = $bcAuthContext.AccessToken
+        Write-Host $accessToken.GetType().FullName
         Write-Host $bcAuthContext.upn
         $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
@@ -348,7 +349,7 @@ try {
                     Write-Host "ACCESSTOKEN"
                     $clientServicesCredentialType = "AAD"
                     Write-Host $credential.UserName
-                    Write-Host "$accessToken".Substring(5)
+                    $accessToken = $accessToken.Trim()
                     $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -348,11 +348,7 @@ try {
                 $serviceUrl = "$publicWebBaseUrl/cs?tenant=$tenant"
     
                 if ($accessToken) {
-                    Write-Host "ACCESSTOKEN"
                     $clientServicesCredentialType = "AAD"
-                    Write-Host $credential.UserName
-                    Write-Host $accessToken
-                    Write-Host $accessToken.Length
                     $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         
@@ -402,8 +398,8 @@ try {
                               -ReRun:$ReRun `
                               -AzureDevOps $AzureDevOps `
                               -GitHubActions $GitHubActions `
-                              -detailed:$true `
-                              -debugMode:$true `
+                              -detailed:$detailed `
+                              -debugMode:$debugMode `
                               -testPage $testPage `
                               -connectFromHost:$connectFromHost
                 }

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -263,6 +263,7 @@ try {
         $accessToken = $bcAuthContext.AccessToken
         Write-Host $accessToken.GetType().FullName
         Write-Host $accessToken
+        Write-Host $accessToken.Length
         Write-Host $bcAuthContext.upn
         $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
@@ -350,7 +351,8 @@ try {
                     Write-Host "ACCESSTOKEN"
                     $clientServicesCredentialType = "AAD"
                     Write-Host $credential.UserName
-                    $accessToken = $accessToken.Trim()
+                    Write-Host $accessToken
+                    Write-Host $accessToken.Length
                     $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -95,9 +95,9 @@ function Run-TestsInBcContainer {
         [Parameter(Mandatory=$false)]
         [string] $profile = "",
         [Parameter(Mandatory=$false)]
-        [PSCredential] $credential = $null,
+        [System.Management.Automation.PSCredential] $credential = $null,
         [Parameter(Mandatory=$false)]
-        [PSCredential] $sqlCredential = $credential,
+        [System.Management.Automation.PSCredential] $sqlCredential = $credential,
         [Parameter(Mandatory=$false)]
         [string] $accessToken = "",
         [Parameter(Mandatory=$false)]
@@ -172,7 +172,7 @@ try {
         if ($environment -like 'https://*') {
             $useUrl = $environment
             if ($bcAuthContext.ContainsKey('Username') -and $bcAuthContext.ContainsKey('Password')) {
-                $credential = New-Object pscredential $bcAuthContext.Username, $bcAuthContext.Password
+                $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $bcAuthContext.Username, $bcAuthContext.Password
                 $clientServicesCredentialType = "NavUserPassword"
             }
             if ($bcAuthContext.ContainsKey('ClientServicesCredentialType')) {
@@ -265,7 +265,7 @@ try {
         Write-Host $accessToken
         Write-Host $accessToken.Length
         Write-Host $bcAuthContext.upn
-        $credential = New-Object pscredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+        $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
 
     $PsTestFunctionsPath = Join-Path $PsTestToolFolder "PsTestFunctions.ps1"
@@ -353,7 +353,7 @@ try {
                     Write-Host $credential.UserName
                     Write-Host $accessToken
                     Write-Host $accessToken.Length
-                    $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+                    $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                 }
         
                 if ($companyName) {
@@ -435,7 +435,7 @@ try {
                     }
                 }
 
-                $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testGroup, [string] $testCodeunit, [string] $testCodeunitRange, [string] $testFunction, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [string] $XUnitResultFileName, [bool] $AppendToXUnitResultFile, [string] $JUnitResultFileName, [bool] $AppendToJUnitResultFile, [bool] $ReRun, [string] $AzureDevOps, [string] $GitHubActions, [bool] $detailed, [timespan] $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests)
+                $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh $false -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [System.Management.Automation.PSCredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testGroup, [string] $testCodeunit, [string] $testCodeunitRange, [string] $testFunction, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [string] $XUnitResultFileName, [bool] $AppendToXUnitResultFile, [string] $JUnitResultFileName, [bool] $AppendToJUnitResultFile, [bool] $ReRun, [string] $AzureDevOps, [string] $GitHubActions, [bool] $detailed, [timespan] $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests)
     
                     $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
                     if (!(Test-Path $newtonSoftDllPath)) {
@@ -461,7 +461,7 @@ try {
             
                     if ($accessToken) {
                         $clientServicesCredentialType = "AAD"
-                        $credential = New-Object pscredential $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
+                        $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $credential.UserName, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
                     }
                     elseif ($clientServicesCredentialType -eq "Windows") {
                         $windowsUserName = whoami

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -258,13 +258,8 @@ try {
     }
 
     if ($bcAuthContext -and ($environment -notlike 'https://*')) {
-        Write-Host "RENEW AUTHCONTEXT"
         $bcAuthContext = Renew-BcAuthContext $bcAuthContext
         $accessToken = $bcAuthContext.AccessToken
-        Write-Host $accessToken.GetType().FullName
-        Write-Host $accessToken
-        Write-Host $accessToken.Length
-        Write-Host $bcAuthContext.upn
         $credential = New-Object System.Management.Automation.PSCredential -ArgumentList $bcAuthContext.upn, (ConvertTo-SecureString -String $accessToken -AsPlainText -Force)
     }
 

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -391,8 +391,8 @@ try {
                               -ReRun:$ReRun `
                               -AzureDevOps $AzureDevOps `
                               -GitHubActions $GitHubActions `
-                              -detailed:$detailed `
-                              -debugMode:$debugMode `
+                              -detailed:$true `
+                              -debugMode:$true `
                               -testPage $testPage `
                               -connectFromHost:$connectFromHost
                 }

--- a/AppHandling/Sign-NavContainerApp.ps1
+++ b/AppHandling/Sign-NavContainerApp.ps1
@@ -151,7 +151,7 @@ try {
             }
 
             Write-Host "Signing $appFile"
-            $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
+            $unsecurepassword = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($pfxPassword)))
             $attempt = 1
             $maxAttempts = 5
             do {

--- a/Artifacts/Download-Artifacts.ps1
+++ b/Artifacts/Download-Artifacts.ps1
@@ -244,14 +244,14 @@ try {
                                 Download-File -sourceUrl "https://go.microsoft.com/fwlink/?LinkID=844461" -destinationFile (Join-Path $dotnetCoreFolder "DotNetCore.1.0.4_1.1.1-WindowsHosting.exe") -timeout $timeout
                             }
                         }
-                        # Patch potential wrong version of NewtonSoft.json.DLL
-                        $newtonSoftDllPath = Join-Path $platformArtifactPath 'ServiceTier\program files\Microsoft Dynamics NAV\210\Service\Newtonsoft.json.dll'
+                        # Patch potential wrong version of Newtonsoft.Json.dll
+                        $newtonSoftDllPath = Join-Path $platformArtifactPath 'ServiceTier\program files\Microsoft Dynamics NAV\210\Service\Newtonsoft.Json.dll'
                         if (Test-Path $newtonSoftDllPath) {
-                            'Applications\testframework\TestRunner\Internal\Newtonsoft.json.dll','Test Assemblies\Newtonsoft.json.dll' | ForEach-Object {
+                            'Applications\testframework\TestRunner\Internal\Newtonsoft.Json.dll','Test Assemblies\Newtonsoft.Json.dll' | ForEach-Object {
                                 $dstFile = Join-Path $platformArtifactPath $_
                                 $file = Get-item -Path $dstFile -ErrorAction SilentlyContinue
                                 if ($file -and $file.Length -eq 686000) {
-                                    Write-Host "INFO: Patching wrong version of NewtonSoft.json.DLL in $dstFile"
+                                    Write-Host "INFO: Patching wrong version of Newtonsoft.Json.dll in $dstFile"
                                     Copy-Item -Path $newtonSoftDllPath -Destination $dstFile -Force 
                                 }
                             }

--- a/AzureAD/Create-AadAppsForNav.ps1
+++ b/AzureAD/Create-AadAppsForNav.ps1
@@ -82,7 +82,7 @@ try {
     }
     else {
         if ($AadAdminCredential) {
-            $password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AadAdminCredential.Password))
+            $password = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AadAdminCredential.Password))
             if ($password.Length -gt 100) {
                 $account = Connect-AzureAD -AadAccessToken $password -AccountId $AadAdminCredential.UserName
             }

--- a/AzureAD/Create-AadUsersInNavContainer.ps1
+++ b/AzureAD/Create-AadUsersInNavContainer.ps1
@@ -62,7 +62,7 @@ try {
     }
     else {
         if ($AadAdminCredential) {
-            $password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AadAdminCredential.Password))
+            $password = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($AadAdminCredential.Password))
             if ($password.Length -gt 100) {
                 $account = Connect-AzureAD -AadAccessToken $password -AccountId $AadAdminCredential.UserName
             }

--- a/Bacpac/Export-NavContainerDatabasesAsBacpac.ps1
+++ b/Bacpac/Export-NavContainerDatabasesAsBacpac.ps1
@@ -193,7 +193,7 @@ try {
 
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
         
             Write-Host "Remove Network Service User from $DatabaseName"
@@ -219,7 +219,7 @@ try {
 
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
         
             Write-Host "Remove Windows Users from $DatabaseName"
@@ -249,7 +249,7 @@ try {
 
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
         
             Write-Host "Remove Application Roles from $DatabaseName"
@@ -280,7 +280,7 @@ try {
             Write-Host "Checking Entitlements"
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
 
             'Membership Entitlement', 'Entitlement Set', 'Entitlement' | % {
@@ -303,7 +303,7 @@ try {
          
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
         
             Write-Host "Remove data from System Tables database $DatabaseName"
@@ -336,7 +336,7 @@ try {
 
             $params = @{ 'ErrorAction' = 'Ignore'; 'ServerInstance' = $databaseServer }
             if ($sqlCredential) {
-                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
             }
         
             if (!($KeepUserData)) {
@@ -416,7 +416,7 @@ try {
                 if ($sqlCredential) {
                     $arguments += @(
                         ('/SourceUser:"'+$sqlCredential.UserName+'"'),
-                        ('/SourcePassword:"'+([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))+'"')
+                        ('/SourcePassword:"'+([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))+'"')
                     )
                 }
     
@@ -447,7 +447,7 @@ try {
                 if ($sqlCredential) {
                     $arguments += @(
                         ('/SourceUser:"'+$sqlCredential.UserName+'"'),
-                        ('/SourcePassword:"'+([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))+'"')
+                        ('/SourcePassword:"'+([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))+'"')
                     )
                 }
 

--- a/Common/Get-PlainText.ps1
+++ b/Common/Get-PlainText.ps1
@@ -14,12 +14,12 @@ function Get-PlainText() {
         [parameter(ValueFromPipeline, Mandatory = $true)]
         [System.Security.SecureString] $SecureString
     )
-    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString);
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
     try {
-        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr);
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
     }
     finally {
-        [Runtime.InteropServices.Marshal]::FreeBSTR($bstr);
+        [Runtime.InteropServices.Marshal]::FreeBSTR($bstr)
     }
 }
 Export-ModuleMember -Function Get-PlainText

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -230,7 +230,6 @@ try {
         $alcExePath = Join-Path $containerCompilerPath 'extension/bin/linux/alc'
         if (Test-Path $alcExePath) {
             # Set execute permissions on alc
-            Write-Host "Setting execute permissions on alc"
             & /usr/bin/env sudo pwsh -command "& chmod +x $alcExePath"
         }
         else {

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -258,11 +258,13 @@ try {
         }
     }
 
-    $symbolsPath = Join-Path $compilerFolder 'symbols'
-    Write-Host "Enumerating Apps in CompilerFolder $symbolsPath"
+    Write-Host "Enumerating Apps in $symbolsPath"
     $compilerFolderAppFiles = @(Get-ChildItem -Path (Join-Path $symbolsPath '*.app') | Select-Object -ExpandProperty FullName)
     GetAppInfo -AppFiles $compilerFolderAppFiles -compilerFolder $compilerFolder -cacheAppinfoPath (Join-Path $symbolsPath 'cache_AppInfo.json') | Out-Null
-
+    if ($cacheFolder) {
+        Write-Host "Copying symbols cache"
+        Copy-Item -Path (Join-Path $symbolsPath 'cache_AppInfo.json') -Destination (Join-Path $compilerFolder 'symbols') -Force
+    }
     $compilerFolder
 }
 catch {

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -128,7 +128,12 @@ try {
         Remove-Item -Path (Join-Path $dllsPath 'Service\SideServices') -Recurse -Force -ErrorAction SilentlyContinue
         New-Item -Path (Join-Path $dllsPath 'OpenXML') -ItemType Directory | Out-Null
         Copy-Item -Path (Join-Path $dllsPath 'Service\DocumentFormat.OpenXml.dll') -Destination (Join-Path $dllsPath 'OpenXML') -Force -ErrorAction SilentlyContinue
-        $mockAssembliesFolder = Join-Path $platformArtifactPath "Test Assemblies\Mock Assemblies" -Resolve
+        $testAssembliesFolder = Join-Path $platformArtifactPath "Test Assemblies" -Resolve
+        $testAssembliesDestination = Join-Path $dllsPath "Test Assemblies"
+        New-Item -Path $testAssembliesDestination -ItemType Directory | Out-Null
+        Copy-Item -Path (Join-Path $testAssembliesFolder 'Newtonsoft.Json.dll') -Destination $testAssembliesDestination -Force
+        Copy-Item -Path (Join-Path $testAssembliesFolder 'Microsoft.Dynamics.Framework.UI.Client.dll') -Destination $testAssembliesDestination -Force
+        $mockAssembliesFolder = Join-Path $testAssembliesFolder "Mock Assemblies" -Resolve
         Copy-Item -Path $mockAssembliesFolder -Filter '*.dll' -Destination $dllsPath -Recurse
         $extensionsFolder = Join-Path $appArtifactPath 'Extensions'
         if (Test-Path $extensionsFolder -PathType Container) {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -1595,7 +1595,7 @@ if (!$restartingInstance) {
     winrm create winrm/config/Listener?Address=*+Transport=HTTPS (''@{Hostname="dontcare"; CertificateThumbprint="'' + $cert.Thumbprint + ''"}'')
     winrm set winrm/config/service/Auth ''@{Basic="true"}''
     Write-Host "Creating Container user $username"
-    New-LocalUser -AccountNeverExpires -PasswordNeverExpires -FullName $username -Name '+$bcContainerHelperConfig.WinRmCredentials.UserName+' -Password (ConvertTo-SecureString -string "'+([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($bcContainerHelperConfig.WinRmCredentials.Password)))+'" -AsPlainText -force) | Out-Null
+    New-LocalUser -AccountNeverExpires -PasswordNeverExpires -FullName $username -Name '+$bcContainerHelperConfig.WinRmCredentials.UserName+' -Password (ConvertTo-SecureString -string "'+([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($bcContainerHelperConfig.WinRmCredentials.Password)))+'" -AsPlainText -force) | Out-Null
     Add-LocalGroupMember -Group administrators -Member '+$bcContainerHelperConfig.WinRmCredentials.UserName+'
 }
 ') | Add-Content -Path "$myfolder\AdditionalSetup.ps1"
@@ -2018,7 +2018,7 @@ if (-not `$restartingInstance) {
                             )
 
             if ("$databaseServer" -ne "" -and $bcContainerHelperConfig.useSharedEncryptionKeys -and !$encryptionKeyExists) {
-                $sharedEncryptionKeyFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "EncryptionKeys\$(-join [security.cryptography.sha256managed]::new().ComputeHash([Text.Encoding]::Utf8.GetBytes(([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))))).ForEach{$_.ToString("X2")})\DynamicsNAV-v$($version.Major).key"
+                $sharedEncryptionKeyFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "EncryptionKeys\$(-join [security.cryptography.sha256managed]::new().ComputeHash([Text.Encoding]::Utf8.GetBytes(([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))))).ForEach{$_.ToString("X2")})\DynamicsNAV-v$($version.Major).key"
                 if (Test-Path $sharedEncryptionKeyFile) {
                     Write-Host "Using Shared Encryption Key file"
                     Copy-Item -Path $sharedEncryptionKeyFile -Destination $containerEncryptionKeyFile

--- a/ContainerInfo/Get-NavContainerImageLabels.ps1
+++ b/ContainerInfo/Get-NavContainerImageLabels.ps1
@@ -36,7 +36,7 @@ function Get-BcContainerImageLabels {
     
         } elseif ($registryCredential) {
     
-            $credentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($registryCredential.UserName + ":" + [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($registryCredential.Password))))
+            $credentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($registryCredential.UserName + ":" + [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($registryCredential.Password))))
             $authorization = "Basic $credentials"
     
         } elseif ("$registry" -eq "bcinsider.azurecr.io" -or "$registry" -eq "bcprivate.azurecr.io") {

--- a/ContainerInfo/Get-NavContainerImageTags.ps1
+++ b/ContainerInfo/Get-NavContainerImageTags.ps1
@@ -33,7 +33,7 @@ function Get-BcContainerImageTags {
 
     } elseif ($registryCredential) {
 
-        $credentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($registryCredential.UserName + ":" + [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($registryCredential.Password))))
+        $credentials = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($registryCredential.UserName + ":" + [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($registryCredential.Password))))
         $authorization = "Basic $credentials"
         if ($pageSize -eq -1) {
             $pageSize = 1000

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -891,7 +891,7 @@ Function CreatePsTestToolFolder {
 
     $PsTestFunctionsPath = Join-Path $PsTestToolFolder "PsTestFunctions.ps1"
     $ClientContextPath = Join-Path $PsTestToolFolder "ClientContext.ps1"
-    $newtonSoftDllPath = Join-Path $PsTestToolFolder "NewtonSoft.json.dll"
+    $newtonSoftDllPath = Join-Path $PsTestToolFolder "Newtonsoft.Json.dll"
     $clientDllPath = Join-Path $PsTestToolFolder "Microsoft.Dynamics.Framework.UI.Client.dll"
 
     if (!(Test-Path -Path $PsTestToolFolder -PathType Container)) {
@@ -902,9 +902,9 @@ Function CreatePsTestToolFolder {
 
     Invoke-ScriptInBcContainer -containerName $containerName { Param([string] $myNewtonSoftDllPath, [string] $myClientDllPath)
         if (!(Test-Path $myNewtonSoftDllPath)) {
-            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\NewtonSoft.json.dll"
+            $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
             if (!(Test-Path $newtonSoftDllPath)) {
-                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\NewtonSoft.json.dll"
+                $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll"
             }
             $newtonSoftDllPath = (Get-Item $newtonSoftDllPath).FullName
             Copy-Item -Path $newtonSoftDllPath -Destination $myNewtonSoftDllPath

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -1056,7 +1056,6 @@ function GetAppInfo {
     if ($isLinux) {
         $alcPath = Join-Path $binPath 'linux'
         $alToolExe = Join-Path $alcPath 'altool'
-        Write-Host "Setting execute permissions on altool"
         & /usr/bin/env sudo pwsh -command "& chmod +x $alToolExe"
     }
     else {
@@ -1276,7 +1275,6 @@ function RunAlTool {
     $path = DownloadLatestAlLanguageExtension -allowPrerelease:$usePrereleaseAlTool
     if ($isLinux) {
         $alToolExe = Join-Path $path 'extension/bin/linux/altool'
-        Write-Host "Setting execute permissions on altool"
         & /usr/bin/env sudo pwsh -command "& chmod +x $alToolExe"
     }
     else {

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -1039,6 +1039,7 @@ function GetAppInfo {
         [string] $cacheAppInfoPath = ''
     )
 
+    Push-Location
     $appInfoCache = $null
     $cacheUpdated = $false
     if ($cacheAppInfoPath) {
@@ -1048,6 +1049,7 @@ function GetAppInfo {
         else {
             $appInfoCache = @{}
         }
+        Set-Location (Split-Path $cacheAppInfoPath -parent)
     }
     Write-Host "::group::Getting .app info $cacheAppInfoPath"
     $binPath = Join-Path $compilerFolder 'compiler/extension/bin'
@@ -1077,8 +1079,9 @@ function GetAppInfo {
     try {
         foreach($path in $appFiles) {
             Write-Host -NoNewline "- $([System.IO.Path]::GetFileName($path))"
-            if ($appInfoCache -and $appInfoCache.PSObject.Properties.Name -eq $path) {
-                $appInfo = $appInfoCache."$path"
+            $relativePath = Resolve-Path -Path $path -Relative
+            if ($appInfoCache -and $appInfoCache.PSObject.Properties.Name -eq $relativePath) {
+                $appInfo = $appInfoCache."$relativePath"
                 Write-Host " (cached)"
             }
             else {
@@ -1125,7 +1128,7 @@ function GetAppInfo {
                     Write-Host " (succeeded using codeanalysis)"
                 }
                 if ($cacheAppInfoPath) {
-                    $appInfoCache | Add-Member -MemberType NoteProperty -Name $path -Value $appInfo
+                    $appInfoCache | Add-Member -MemberType NoteProperty -Name $relativePath -Value $appInfo
                     $cacheUpdated = $true
                 }
             }
@@ -1162,6 +1165,7 @@ function GetAppInfo {
         if ($packageStream) {
             $packageStream.Dispose()
         }
+        Pop-Location
     }
     Write-Host "::endgroup::"
 }

--- a/NavContainerHelper.md
+++ b/NavContainerHelper.md
@@ -861,7 +861,7 @@ In this example, it gets the .mdf and .ldf files from the latest cumulative upda
     $databaseCredential = New-Object System.Management.Automation.PSCredential -argumentList "sa", (ConvertTo-SecureString -String "P@ssword1" -AsPlainText -Force)
     $databaseName = "CRONUS"
     $attach_dbs = (ConvertTo-Json -Compress -Depth 99 @(@{"dbName" = "$databaseName"; "dbFiles" = @("c:\temp\${databaseName}.mdf", "c:\temp\${databaseName}.ldf") })).replace('"',"'")
-    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
+    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
     $dbserverid = docker run -d -e sa_password="$dbPassword" -e ACCEPT_EULA=Y -v "${hostFolder}:C:/temp" -e attach_dbs="$attach_dbs" microsoft/mssql-server-windows-developer
     $databaseServer = $dbserverid.SubString(0,12)
     $databaseInstance = ""
@@ -877,7 +877,7 @@ The following script sample, will create a new SQL Server container and restore 
 
     $hostFolder = "c:\temp\navdbfiles"
     $databaseCredential = New-Object System.Management.Automation.PSCredential -argumentList "sa", (ConvertTo-SecureString -String "P@ssword1" -AsPlainText -Force)
-    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
+    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
     $dbserverid = docker run -d -e sa_password="$dbPassword" -e ACCEPT_EULA=Y -v "${hostFolder}:C:/temp" microsoft/mssql-server-windows-express
     $databaseServer = $dbserverid.SubString(0,12)
     $databaseInstance = ""
@@ -903,7 +903,7 @@ Then you will have the variables $databaseServer, $databaseInstance, $databaseNa
 
 If you have created your external database through other means, please set these variables in PowerShell. Please try the following script to see whether a docker container can connect to your database:
 
-    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
+    $dbPassword = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
     $databaseServerInstance = @{ $true = "$databaseServer\$databaseInstance"; $false = "$databaseServer"}["$databaseInstance" -ne ""]
     docker run -it --name sqlconnectiontest microsoft/mssql-server-windows-developer powershell -command "Invoke-Sqlcmd -ServerInstance '$databaseServerInstance' -Username '$($databaseCredential.Username)' -Password '$dbPassword' -Database '$databaseName' -Query 'SELECT COUNT(*) FROM [dbo].[User]'"
 

--- a/ObjectHandling/Compile-ObjectsInNavContainer.ps1
+++ b/ObjectHandling/Compile-ObjectsInNavContainer.ps1
@@ -59,7 +59,7 @@ try {
 
         $params = @{}
         if ($sqlCredential) {
-            $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+            $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
         }
         Compile-NAVApplicationObject @params -Filter $filter `
                                      -DatabaseName $databaseName `

--- a/ObjectHandling/Export-NavContainerObjects.ps1
+++ b/ObjectHandling/Export-NavContainerObjects.ps1
@@ -107,7 +107,7 @@ try {
 
         $params = @{ 'ExportTxtSkipUnlicensed' = $true }
         if ($sqlCredential) {
-            $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+            $params += @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
         }
         if ($exportTo.Contains('(new syntax)')) {
             $params += @{ 'ExportToNewSyntax' = $true }

--- a/ObjectHandling/Import-ObjectsToNavContainer.ps1
+++ b/ObjectHandling/Import-ObjectsToNavContainer.ps1
@@ -57,7 +57,7 @@ try {
     
         $params = @{}
         if ($sqlCredential) {
-            $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+            $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
         }
         if ($suppressBuildSearchIndex) {
             $params += @{ "suppressBuildSearchIndex" = $suppressBuildSearchIndex }

--- a/ObjectHandling/Import-TestToolkitToNavContainer.ps1
+++ b/ObjectHandling/Import-TestToolkitToNavContainer.ps1
@@ -254,7 +254,7 @@ try {
            
                 $params = @{}
                 if ($sqlCredential) {
-                    $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
+                    $params = @{ 'Username' = $sqlCredential.UserName; 'Password' = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password))) }
                 }
                 if ($testToolkitCountry) {
                     $fileFilter = "*.$testToolkitCountry.fob"

--- a/ObjectHandling/Import-TestToolkitToNavContainer.ps1
+++ b/ObjectHandling/Import-TestToolkitToNavContainer.ps1
@@ -111,7 +111,7 @@ try {
             if ($appVersion.Major -eq 18 -and $appVersion.Minor -eq 0) {
                 $targetVersion = "18.0.23013.23913"
             }
-            $installedApp = $installedApps | Where-Object { $_.id -eq $appId -and ($targetVersion -and ([Version]($_.version) -ge [Version]$targetVersion)) }
+            $installedApp = $installedApps | Where-Object { $_.id -eq $appId -and (($targetVersion -eq "") -or ([Version]($_.version) -ge [Version]$targetVersion)) }
             if ($installedApp) {
                 Write-Host "Skipping app '$($installedApp.name)' as it is already installed"
             }

--- a/PackageHandling/Publish-BuildOutputToStorage.ps1
+++ b/PackageHandling/Publish-BuildOutputToStorage.ps1
@@ -42,7 +42,7 @@ function Publish-BuildOutputToStorage {
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
 
-    if ($StorageConnectionString -is [SecureString]) { $StorageConnectionString = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($StorageConnectionString)) }
+    if ($StorageConnectionString -is [SecureString]) { $StorageConnectionString = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($StorageConnectionString)) }
     if ($StorageConnectionString -isnot [string]) { throw "StorageConnectionString needs to be a SecureString or a String" }
     $projectName = $projectName.ToLowerInvariant()
     $appVersion = $appVersion.ToLowerInvariant()

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -440,7 +440,7 @@ Use a PowerShell Job to run bcpt tests to be able to remove files afterwards
 Allow Get-BcContainerAppInfo to be used without explicitely specifying -containerName $containerName, allowing just $containerName
 Add new function Set-BcContainerServerConfiguration to directly configure settings of the Business Central Server instance (without needing Invoke-ScriptInBcContainer)
 Add new function Restart-BcContainerServiceTier to restart only the service tier after configuration changes (often necessary)
-Patch wrong version of Newtonsoft.json.dll in current insider builds (until this is fixed in the platform)
+Patch wrong version of Newtonsoft.Json.dll in current insider builds (until this is fixed in the platform)
 
 3.0.8
 Add new function Get-ALGoAuthContext to get AL-Go for GitHub compatible auth context from bcAuthContext obtained from New-BcAuthContext

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,8 @@
 Add trustServerCertificate is the parameter exists in various functions that might be running on the host
 Issue #3594 Run-AlCops says unknown platform version
 Add information about apps excluded due to not being referenced during Publish-BcContainerApp
+Run-AlPipeline to support CompilerFolder and online environments for building and testing
+New override in Run-AlPipeline GetBcPublishedApps to return which published apps exists in bcauthContext and environment
 
 6.0.19
 Issue #3560 Backup-BcContainerDatabases fails - password must be marked as read only bug

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -3,7 +3,7 @@ Add trustServerCertificate is the parameter exists in various functions that mig
 Issue #3594 Run-AlCops says unknown platform version
 Add information about apps excluded due to not being referenced during Publish-BcContainerApp
 Run-AlPipeline to support CompilerFolder and online environments for building and testing
-New override in Run-AlPipeline GetBcPublishedApps to return which published apps exists in bcauthContext and environment
+Added 2 new overrides in Run-AlPipeline: PipelineInitialize and PipelineFinalize
 
 6.0.19
 Issue #3560 Backup-BcContainerDatabases fails - password must be marked as read only bug

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,12 @@ Issue #3594 Run-AlCops says unknown platform version
 Add information about apps excluded due to not being referenced during Publish-BcContainerApp
 Run-AlPipeline to support CompilerFolder and online environments for building and testing
 Added 2 new overrides in Run-AlPipeline: PipelineInitialize and PipelineFinalize
+Add parameter CompilerFolder to Run-TestsInBcContainer and Import-TestToolkitToBcContainer for running tests using CompilerFolder bits from the host
+Replace all occurrences of [System.Runtime.InteropServices.Marshal]::PtrToStringAuto with [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR as the Auto function doesn't always do what's expected under Linux
+Ensure correct casing of Newtonsoft.Json.dll for Linux
+Always add extensionId (when specified) to Properties section in test results xml
+If environment is specified as a Web Client URL, and BcAuthContext contains username/password in Run-AlPipeline, then tests will run against this environment. PublishBcContainerApp and ImportTestToolkitToBcContainer needs to be overridden for this to work with full pipeline.
+Including caching of appinfos in CompilerFolder cache (to save time when caching on GitHub Actions)
 
 6.0.19
 Issue #3560 Backup-BcContainerDatabases fails - password must be marked as read only bug

--- a/Saas/Publish-PerTenantExtensionApps.ps1
+++ b/Saas/Publish-PerTenantExtensionApps.ps1
@@ -60,7 +60,7 @@ try {
     }
 
     if ($PsCmdlet.ParameterSetName -eq "CC") {
-        if ($clientId -is [SecureString]) { $clientID = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($clientID)) }
+        if ($clientId -is [SecureString]) { $clientID = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($clientID)) }
         if ($clientId -isnot [String]) { throw "ClientID needs to be a SecureString or a String" }
         if ($clientSecret -is [String]) { $clientSecret = ConvertTo-SecureString -String $clientSecret -AsPlainText -Force }
         if ($clientSecret -isnot [SecureString]) { throw "ClientSecret needs to be a SecureString or a String" }

--- a/SymbolHandling/Generate-SymbolsInNavContainer.ps1
+++ b/SymbolHandling/Generate-SymbolsInNavContainer.ps1
@@ -37,7 +37,7 @@ try {
         $ProcessArguments += "Command=generatesymbolreference, Database=""$databaseName"", ServerName=""$databaseServer"""
         if ($sqlCredential) {
             Write-Host "Adding SQL-Server credentials for authentication"
-            $ProcessArguments += ", ntauthentication=0, username=""$($sqlCredential.UserName)"", password=""$([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))"""
+            $ProcessArguments += ", ntauthentication=0, username=""$($sqlCredential.UserName)"", password=""$([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sqlCredential.Password)))"""
         }
 
         Write-Host "Creating application symbols in $containerName"

--- a/UserHandling/New-NavContainerNavUser.ps1
+++ b/UserHandling/New-NavContainerNavUser.ps1
@@ -101,7 +101,7 @@ try {
                 $sqlparams += @{
                     "ServerInstance" = $databaseServerInstance
                     "Username" = $databaseCredential.Username
-                    "Password" = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
+                    "Password" = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($databaseCredential.Password))
                 }
             }
         }

--- a/UserHandling/Setup-NavContainerTestUsers.ps1
+++ b/UserHandling/Setup-NavContainerTestUsers.ps1
@@ -121,7 +121,7 @@ try {
 
         $parameters = @{ 
             "name" = "CreateTestUsers$select"
-            "value" = ([System.Runtime.InteropServices.Marshal]::PtrToStringAuto([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)))
+            "value" = ([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR([System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($Password)))
         }
         Invoke-BcContainerApi -containerName $containerName -tenant $tenant -credential $credential -APIPublisher "Microsoft" -APIGroup "Setup" -APIVersion "beta" -CompanyId $companyId -Method "POST" -Query "testUsers" -body $parameters | Out-Null
 


### PR DESCRIPTION
When specifying BcAuthContext and Environment to Run-AlPipeline, Run-AlPipeline would always create a filesonly container, disallowing running on Linux.
This PR fixes this plus some bugs found as a result of this.

- Replace all occurrences of [System.Runtime.InteropServices.Marshal]::PtrToStringAuto with [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR as the Auto function doesn't always do what's expected under Linux (We do not use the Auto function in AL-Go)
- Ensure correct casing of Newtonsoft.Json.dll for Linux (also not a problem in AL-Go)
- Always add extensionId (when specified) to Properties section in test results xml
- Also added two new overrides (PipelineInitialize and PipelineFinalize) requested by COSMO Consult.
- If environment is specified as a Web Client URL, and BcAuthContext contains username/password in Run-AlPipeline, then tests will run against this environment. PublishBcContainerApp and ImportTestToolkitToBcContainer needs to be overridden for this to work with full pipeline.
- Add parameter CompilerFolder to Run-TestsInBcContainer and Import-TestToolkitToBcContainer for running tests using CompilerFolder bits from the host
- Including caching of appinfos in CompilerFolder cache (to save time when caching on GitHub Actions)

Running Build AND Test under Linux (using CompilerFolder), using an online environment as "Service Tier" can be seen here:
https://github.com/BusinessCentralDemos/bingmaps.pte/actions/runs/10313615507

Build and test here takes approx. 3 minutes.

This functionality is needed by COSMO to enable using their Docker Swarm for running tests in AL-Go.

COSMO is aware that AL-Go moves away from using BcContainerHelper and will subsequently have to change their integration when this has happened.
