### PR TITLE
Freddydk/issue3686

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -2168,10 +2168,15 @@ if (-not `$restartingInstance) {
                 $vs = "NAV"
             }
             $cmdPrompt = "/S /K ""prompt [$($containerName.ToUpperInvariant())] `$p`$g & echo Welcome to the $vs Container Command prompt & echo Microsoft Windows Version $($containerOsVersion.ToString())"
-            $psPrompt = """function prompt {'[$($containerName.ToUpperInvariant())] PS '+`$executionContext.SessionState.Path.CurrentLocation+('>'*(`$nestedPromptLevel+1))+' '}; Write-Host 'Welcome to the $vs Container PowerShell prompt'; Write-Host 'Microsoft Windows Version $($containerOsVersion.ToString())'; Write-Host 'Windows PowerShell Version $($PSVersionTable.psversion.ToString())'; Write-Host; . 'c:\run\prompt.ps1' -silent"""
+            $psPrompt = """function prompt {'[$($containerName.ToUpperInvariant())] PS '+`$executionContext.SessionState.Path.CurrentLocation+('>'*(`$nestedPromptLevel+1))+' '}; Write-Host 'Welcome to the $vs Container PowerShell prompt'; Write-Host 'Microsoft Windows Version $($containerOsVersion.ToString())'; "+'Write-Host "Windows PowerShell Version $($PSVersionTable.psversion.ToString())"; Write-Host; . "c:\run\prompt.ps1" -silent"'
 
             New-DesktopShortcut -Name "$containerName Command Prompt" -TargetPath "CMD.EXE" -Arguments "/C docker.exe exec -it $containerName cmd $cmdPrompt" -Shortcuts $shortcuts
-            New-DesktopShortcut -Name "$containerName PowerShell Prompt" -TargetPath "CMD.EXE" -Arguments "/C docker.exe exec -it $containerName powershell -noexit $psPrompt" -Shortcuts $shortcuts
+            $psname = "PowerShell"
+            if ($version.Major -ge 24) {
+                New-DesktopShortcut -Name "$containerName $psname Prompt" -TargetPath "CMD.EXE" -Arguments "/C docker.exe exec -it $containerName pwsh -noexit -command $psPrompt" -Shortcuts $shortcuts
+                $psname = "PS5"
+            }
+            New-DesktopShortcut -Name "$containerName $psname Prompt" -TargetPath "CMD.EXE" -Arguments "/C docker.exe exec -it $containerName powershell -noexit $psPrompt" -Shortcuts $shortcuts
         }
 
         if ($version -eq [System.Version]"14.10.40471.0") {

--- a/ContainerHandling/Remove-NavContainer.ps1
+++ b/ContainerHandling/Remove-NavContainer.ps1
@@ -107,6 +107,7 @@ try {
         Remove-DesktopShortcut -Name "$containerName CSIDE"
         Remove-DesktopShortcut -Name "$containerName Command Prompt"
         Remove-DesktopShortcut -Name "$containerName PowerShell Prompt"
+        Remove-DesktopShortcut -Name "$containerName PS5 Prompt"
 
         if (Test-Path $containerFolder) {
             $wait = 10

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 6.0.25
 Fix issue where generateDependencyArtifact doesn't result in dependencies if useCompilerFolder is true or filesonly containers are used in Run-AlPipeline
+Issue 3686 PowerShell container shortcuts for >= BC24 using wrong PowerShell version
 
 6.0.24
 Use pre-release altool when running alcops (to be able to get runtime version of nextmajor)


### PR DESCRIPTION
Fixes #3686 

Default PowerShell shortcut will now point to PowerShell 7 on BC24 + (but there will be an additional PS5 shortcut as well).