### PR TITLE
Fix bug in Download-BcNuGetPackageToFolder

### DIFF
--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -231,7 +231,7 @@ try {
                         }
                     }
                     elseif ($downloadDependencies -eq 'own') {
-                        $downloadIt = ($dependencyPublisher -eq $manifest.package.authors)
+                        $downloadIt = ($dependencyPublisher -eq $manifest.package.metadata.authors)
                     }
                     elseif ($downloadDependencies -eq 'allButMicrosoft') {
                         # Download if publisher isn't Microsoft (including if publisher is empty)


### PR DESCRIPTION
Error occurs when using -downloadDependencies with value 'own' because of an invalid reference

This fixes that by correcting the reference, allowing to download dependencies where the author matches