### PR TITLE
Copy Business Foundation Test Libraries app to symbols folder in New-BcCompilerFolder

### DIFF
--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -146,7 +146,7 @@ try {
             if ($appAppsPath) {
                 $appApps = @(Get-ChildItem -Path $appAppsPath -Filter '*.app' -Recurse)
             }
-            'Microsoft_Tests-*.app','Microsoft_Performance Toolkit Samples*.app','Microsoft_Performance Toolkit Tests*.app','Microsoft_System Application Test Library*.app','Microsoft_TestRunner-Internal*.app' | ForEach-Object {
+            'Microsoft_Tests-*.app','Microsoft_Performance Toolkit Samples*.app','Microsoft_Performance Toolkit Tests*.app','Microsoft_System Application Test Library*.app','Microsoft_TestRunner-Internal*.app','Microsoft_Business Foundation Test Libraries*.app' | ForEach-Object {
                 $appName = $_
                 $apps = $appApps | Where-Object { $_.Name -like $appName }
                 if (!$apps) {

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -146,7 +146,7 @@ try {
             if ($appAppsPath) {
                 $appApps = @(Get-ChildItem -Path $appAppsPath -Filter '*.app' -Recurse)
             }
-            'Microsoft_Tests-*.app','Microsoft_Performance Toolkit Samples*.app','Microsoft_Performance Toolkit Tests*.app','Microsoft_System Application Test Library*.app','Microsoft_TestRunner-Internal*.app','Microsoft_Business Foundation Test Libraries*.app' | ForEach-Object {
+            'Microsoft_Tests-*.app','Microsoft_Performance Toolkit Samples*.app','Microsoft_Performance Toolkit Tests*.app','Microsoft_System Application Test Library*.app','Microsoft_TestRunner-Internal*.app','Microsoft_Business Foundation Test Libraries*.app','Microsoft_AI Test Toolkit*.app' | ForEach-Object {
                 $appName = $_
                 $apps = $appApps | Where-Object { $_.Name -like $appName }
                 if (!$apps) {


### PR DESCRIPTION
I probably found a missing app handling in `New-BcCompilerFolder`. When populating the cache folder, "Business Foundation Test Libraries" is not being copied to the symbols folder. Therefore, apps that have a dependency on it will not compile due to missing symbols.

Example:
```
$artifactURL = "https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/sandbox/25.0.23364.25278/de"
$compilerFolder = New-BcCompilerFolder -artifactUrl $artifactURL -includeAL
$symbolsFolder = Join-Path $compilerFolder "symbols"

$filePattern = "Microsoft_Business Foundation Test Libraries*.app"
$fileCheck = Get-ChildItem -Path $symbolsFolder -Filter $filePattern
if ($fileCheck) {
    Write-Host "File exists in the folder: $symbolsFolder" # result with fix
} else {
    Write-Host "File does NOT exist in the folder: $symbolsFolder"  # result without the fix
}
```