### PR TITLE
Fix init of addDependencies

### DIFF
--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -187,7 +187,7 @@ try {
         $existingApp = $existingApps | Where-Object {
             ((($dependency.appId -ne '' -and $_.AppId -eq $dependency.appId) -or ($dependency.appId -eq '' -and $_.Name -eq $dependency.Name)) -and ([System.Version]$_.Version -ge [System.Version]$dependency.version))
         } | Sort-Object { [System.Version]$_.Version } -Descending | Select-Object -First 1
-        $addDependencies = $()
+        $addDependencies = @()
         if ($existingApp) {
             Write-Host "Dependency App exists"
             if ($existingApp.ContainsKey('PropagateDependencies') -and $existingApp.PropagateDependencies -and $existingApp.ContainsKey('Dependencies')) {


### PR DESCRIPTION
We've been seeing tons of errors like this in the latest preview version of containerhelper: 
https://github.com/microsoft/BCApps/actions/runs/11379580839/job/31657319047#step:8:1194

```
Error: Unexpected error when running action. Error Message: The property 'appid' cannot be found on this object. Verify that the property exists.,
```

As far as I can see it's because the addDependencies isn't initialized correctly