### PR TITLE
Fix CheckRelativePath

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -419,7 +419,7 @@ Param(
 function CheckRelativePath([string] $baseFolder, [string] $sharedFolder, $path, $name) {
     if ($path -and $path -notlike 'https://*') {
         if (-not [System.IO.Path]::IsPathRooted($path)) {
-            if (Test-Path -path (Join-Path $baseFolder $path) -PathType Container) {
+            if (Test-Path -Path (Join-Path $baseFolder $path)) {
                 $path = Join-Path $baseFolder $path -Resolve
             }
             else {


### PR DESCRIPTION
`Run-AlPipeline` fails with message like:
```
Error: AL1033 An error occurred while loading the included rule set file c:\sources\..\..\..\src\rulesets\ruleset.json - Could not find a part of the path 'c:\src\rulesets\ruleset.json'.
```

E.g. https://github.com/microsoft/BCApps/actions/runs/11567038300/job/32196982417?pr=2272