### PR TITLE
normalize nuget version on FindPackageVersion

### DIFF
--- a/NuGet/NuGetFeedClass.ps1
+++ b/NuGet/NuGetFeedClass.ps1
@@ -277,7 +277,7 @@ class NuGetFeed {
             if ($excludeVersions -contains $version) {
                 continue
             }
-            if (($select -eq 'Exact' -and [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange) -eq [NuGetFeed]::NormalizeVersionStr($version)) -or ($select -ne 'Exact' -and [NuGetFeed]::IsVersionIncludedInRange($version, $nuGetVersionRange))) {
+            if (($select -eq 'Exact' -and [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange) -eq [NuGetFeed]::NormalizeVersionStr($version)) -or ($select -ne 'Exact' -and [NuGetFeed]::IsVersionIncludedInRange([NuGetFeed]::NormalizeVersionStr($version), [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange))) {
                 if ($nuGetVersionRange -eq '0.0.0.0') {
                     Write-Host "$select version is $version"
                 }

--- a/NuGet/NuGetFeedClass.ps1
+++ b/NuGet/NuGetFeedClass.ps1
@@ -277,7 +277,7 @@ class NuGetFeed {
             if ($excludeVersions -contains $version) {
                 continue
             }
-            if (($select -eq 'Exact' -and [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange) -eq [NuGetFeed]::NormalizeVersionStr($version)) -or ($select -ne 'Exact' -and [NuGetFeed]::IsVersionIncludedInRange([NuGetFeed]::NormalizeVersionStr($version), [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange))) {
+            if (($select -eq 'Exact' -and [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange) -eq [NuGetFeed]::NormalizeVersionStr($version)) -or ($select -ne 'Exact' -and [NuGetFeed]::IsVersionIncludedInRange([NuGetFeed]::NormalizeVersionStr($version), [NuGetFeed]::NormalizeVersionStr($nuGetVersionRange)))) {
                 if ($nuGetVersionRange -eq '0.0.0.0') {
                     Write-Host "$select version is $version"
                 }


### PR DESCRIPTION
#3590

fixing FindPackageVersion for runtime packages with versions with trailing 0  in build or revision.