### PR TITLE
[BcNuGet] Reduce memory consumption, improve performance, prevent memory leaks

### DIFF
--- a/NuGet/New-BcNuGetPackage.ps1
+++ b/NuGet/New-BcNuGetPackage.ps1
@@ -286,7 +286,11 @@ Function New-BcNuGetPackage {
         if (Test-Path $nuPkgFile -PathType Leaf) {
             Remove-Item $nupkgFile -Force
         }
-        Compress-Archive -Path "$rootFolder\*" -DestinationPath "$nupkgFile.zip" -Force
+        if (Test-Path "$nupkgFile.zip" -PathType Leaf) {
+            Remove-Item "$nupkgFile.zip" -Force
+        }
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory("$rootFolder", "$nupkgFile.zip", [System.IO.Compression.CompressionLevel]::Optimal, $false)
         Rename-Item -Path "$nupkgFile.zip" -NewName $nuPkgFileName
         
         $size = (Get-Item $nupkgFile).Length

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 6.0.29
 Issue 3591 When using Publish-NAVApp to publish an app, which fails compilation in the service, the command might hang forever - the fix for this is a temporary hack put in place for the versions which doesn't work.
+Improve performance and reduce memory consumption when creating and pushing NuGet packages
 
 6.0.28
 Set useApproximateVersion to true in settings to increase performance of Get-BcArtifactUrl when selecting latest artifact, by using an approximate filtering on blobs


### PR DESCRIPTION
We found that `Compress-Archive` and especially storing the `octet-stream` inside a string instead of using a Stream causes a very high memory consumption and a bad performance.

We're invoking the BcNuGet Cmdlets from our own C# API and therefore were able to profile the memory and performance. The behaviour however is similar when invoking the Cmdlets directly (PowerShell Core 7.4.6).

**Memory (Note: around 340 MB is the base load our API brings with it)**

Before: Memory spikes when uploading big apps, around 1 GB memory consumption from BcNuGet Cmdlets
<img width="502" alt="image" src="https://github.com/user-attachments/assets/81d81377-304f-459f-a8b3-dd1fbe187b8c">

After: 
<img width="497" alt="image" src="https://github.com/user-attachments/assets/6bb2fcd3-0889-4619-b333-341b200050b8">


**Performance**

Before:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/62747a1e-751a-4b89-bd62-adcd347d31a0">

After:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/be427969-c7cc-4bf4-a05d-43894163998b">

