### PR TITLE
Give Option to Choose SQL PowerShell Module When Restoring From BacPac

### DIFF
--- a/BC.HelperFunctions.ps1
+++ b/BC.HelperFunctions.ps1
@@ -119,6 +119,7 @@ function Get-ContainerHelperConfig {
             "IsAzureDevOps" = ($env:TF_BUILD -eq "true")
             "IsGitLab" = ($env:GITLAB_CI -eq "true")
             "useApproximateVersion" = $false
+            "useSqlServerModule" = $false
         }
 
         if ($isInsider) {

--- a/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
+++ b/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
@@ -23,7 +23,7 @@
  .Parameter sqlTimeout
   SQL Timeout for database restore operations
  .Parameter useSqlServerModule
-  Switch, forces the use of the sqlserver module instead of the sqlps module
+  Switch, forces the use of the sqlserver module instead of the sqlps module. Default is to use the sqlps module. The default can be changed in the bcContainerHelperConfig file by setting "useSqlServerModule" = $false.
 #>
 function Restore-BcDatabaseFromArtifacts {
     Param(
@@ -42,7 +42,7 @@ function Restore-BcDatabaseFromArtifacts {
         [switch] $multitenant,
         [switch] $async,
         [int] $sqlTimeout = -1,
-        [switch] $useSqlServerModule
+        [switch] $useSqlServerModule = $bcContainerHelperConfig.useSqlServerModule
     )
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
@@ -101,6 +101,7 @@ try {
             if ($multitenant) {
                 $dbName = "$($databasePrefix)tenant"
             }
+            $sqlpsModule = $null
             if(-not $useSqlServerModule) {
                 Import-Module sqlps -ErrorAction SilentlyContinue
                 $sqlpsModule = get-module sqlps
@@ -227,7 +228,7 @@ try {
             throw
         }
     
-    } -ArgumentList $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout, $useSqlServerModule
+    } -ArgumentList $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout, $useSqlServerModule.IsPresent
 
     if (!$async) {
         While ($job.State -eq "Running") {

--- a/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
+++ b/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
@@ -60,7 +60,7 @@ try {
     $containerHelperPath = (Get-Item (Join-Path $PSScriptRoot "..\Import-BcContainerHelper.ps1")).FullName
     Write-Host $containerHelperPath
 
-    $job = Start-Job -ScriptBlock { Param( $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout )
+    $job = Start-Job -ScriptBlock { Param( $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout, $sqlModuleToUse )
         $ErrorActionPreference = "Stop"
         try {
             . "$containerHelperPath"
@@ -228,7 +228,7 @@ try {
             throw
         }
     
-    } -ArgumentList $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout
+    } -ArgumentList $containerHelperPath, $artifactUrl, $databaseServer, $databaseInstance, $databasePrefix, $databaseName, $multitenant, $successFileName, $bakFile, $sqlTimeout, $sqlModuleToUse
 
     if (!$async) {
         While ($job.State -eq "Running") {

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -179,8 +179,8 @@
   Use Get-AlLanguageExtensionFromArtifacts -artifactUrl (Get-BCArtifactUrl -select NextMajor -accept_insiderEula) to get latest insider .vsix
  .Parameter sqlTimeout
   SQL Timeout for database restore operations
- .Parameter sqlModuleToUse
-  SQL The SQL PowerShell module to use. The options are sqlps and sqlserver. The default is sqlps.
+ .Parameter useSqlServerModule
+  Switch, forces the use of the sqlserver module instead of the sqlps module
  .Example
   New-BcContainer -accept_eula -containerName test
  .Example
@@ -290,7 +290,7 @@ function New-BcContainer {
         [string] $vsixFile = "",
         [string] $applicationInsightsKey,
         [scriptblock] $finalizeDatabasesScriptBlock,
-        [ValidateSet('sqlps','sqlserver')][String] $sqlModuleToUse = "sqlps"
+        [switch] $useSqlServerModule
     )
 
 $telemetryScope = InitTelemetryScope `
@@ -529,7 +529,7 @@ try {
                 $multitenant = $bcContainerHelperConfig.sandboxContainersAreMultitenantByDefault
             }
             Remove-BcDatabase -databaseServer $databaseServer -databaseInstance $databaseInstance -databaseName "$($databasePrefix)%"
-            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -sqlModuleToUse $sqlModuleToUse -async
+            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -useSqlServerModule $useSqlServerModule -async
             $createTenantAndUserInExternalDatabase = $true
             $bakFile = ""
             $successFileName = Join-Path $bcContainerHelperConfig.containerHelperFolder "$($databasePrefix)databasescreated.txt"

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -180,7 +180,7 @@
  .Parameter sqlTimeout
   SQL Timeout for database restore operations
  .Parameter useSqlServerModule
-  Switch, forces the use of the sqlserver module instead of the sqlps module
+  Switch, forces the use of the sqlserver module instead of the sqlps module. Default is to use the sqlps module. The default can be changed in the bcContainerHelperConfig file by setting "useSqlServerModule" = $false.
  .Example
   New-BcContainer -accept_eula -containerName test
  .Example
@@ -290,7 +290,7 @@ function New-BcContainer {
         [string] $vsixFile = "",
         [string] $applicationInsightsKey,
         [scriptblock] $finalizeDatabasesScriptBlock,
-        [switch] $useSqlServerModule
+        [switch] $useSqlServerModule = $bcContainerHelperConfig.useSqlServerModule
     )
 
 $telemetryScope = InitTelemetryScope `
@@ -529,7 +529,7 @@ try {
                 $multitenant = $bcContainerHelperConfig.sandboxContainersAreMultitenantByDefault
             }
             Remove-BcDatabase -databaseServer $databaseServer -databaseInstance $databaseInstance -databaseName "$($databasePrefix)%"
-            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -useSqlServerModule $useSqlServerModule -async
+            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -useSqlServerModule:$useSqlServerModule.IsPresent -async
             $createTenantAndUserInExternalDatabase = $true
             $bakFile = ""
             $successFileName = Join-Path $bcContainerHelperConfig.containerHelperFolder "$($databasePrefix)databasescreated.txt"

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -179,6 +179,8 @@
   Use Get-AlLanguageExtensionFromArtifacts -artifactUrl (Get-BCArtifactUrl -select NextMajor -accept_insiderEula) to get latest insider .vsix
  .Parameter sqlTimeout
   SQL Timeout for database restore operations
+ .Parameter sqlModuleToUse
+  SQL The SQL PowerShell module to use. The options are sqlps and sqlserver. The default is sqlps.
  .Example
   New-BcContainer -accept_eula -containerName test
  .Example
@@ -287,7 +289,8 @@ function New-BcContainer {
         [switch] $doNotUseRuntimePackages = $true,
         [string] $vsixFile = "",
         [string] $applicationInsightsKey,
-        [scriptblock] $finalizeDatabasesScriptBlock
+        [scriptblock] $finalizeDatabasesScriptBlock,
+        [ValidateSet('sqlps','sqlserver')][String] $sqlModuleToUse = "sqlps"
     )
 
 $telemetryScope = InitTelemetryScope `
@@ -526,7 +529,7 @@ try {
                 $multitenant = $bcContainerHelperConfig.sandboxContainersAreMultitenantByDefault
             }
             Remove-BcDatabase -databaseServer $databaseServer -databaseInstance $databaseInstance -databaseName "$($databasePrefix)%"
-            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -async
+            Restore-BcDatabaseFromArtifacts -artifactUrl $artifactUrl -databaseServer $databaseServer -databaseInstance $databaseInstance -databasePrefix $databasePrefix -databaseName $databaseName -multitenant:$multitenant -bakFile $bakFile -sqlModuleToUse $sqlModuleToUse -async
             $createTenantAndUserInExternalDatabase = $true
             $bakFile = ""
             $successFileName = Join-Path $bcContainerHelperConfig.containerHelperFolder "$($databasePrefix)databasescreated.txt"

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,7 @@
+6.0.30
+Issue 3762 Give Option to Choose SQL PowerShell Module When Restoring From BacPac
+There are instances where sqlps does not work as expected when it is installed. This change adds a switch parameter, useSqlServerModule, to Restore-BcDatabaseFromArtifacts, New-NavContainer, and the BcContainerHelper config file.
+
 6.0.29
 Issue 3591 When using Publish-NAVApp to publish an app, which fails compilation in the service, the command might hang forever - the fix for this is a temporary hack put in place for the versions which doesn't work.
 Improve performance and reduce memory consumption when creating and pushing NuGet packages


### PR DESCRIPTION
Fixes #3762 

This is a change to how Restore-BcDatabaseFromArtifacts chooses which PowerShell module to use. I have added an optional parameter, SqlModuleToUse, with two possible values, sqlps and sqlserver, and a default value of sqlps to preserve existing functionality.

I've also added the same parameter to New-BcContainer.