### PR TITLE
EarliestMatching search for Download-BcNuGetPackageToFolder

### DIFF
--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -254,7 +254,7 @@ try {
                         throw $dependenciesErr
                     }
                     else {
-                            # If we are looking for the earliest/latest matching version, then we can try to find another version
+                        # If we are looking for the earliest/latest matching version, then we can try to find another version
                         Write-Host "WARNING: $dependenciesErr"
                         break
                     }
@@ -264,11 +264,11 @@ try {
                         # Downloading Microsoft packages for a specific version
                         $dependencyVersion = $version
                     }
-                        $returnValue += Download-BcNuGetPackageToFolder -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $dependencyId -version $dependencyVersion -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
+                    $returnValue += Download-BcNuGetPackageToFolder -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $dependencyId -version $dependencyVersion -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                 }
             }
             if ($dependenciesErr) {
-                    # If we are looking for the earliest/latest matching version, then we can try to find another version
+                # If we are looking for the earliest/latest matching version, then we can try to find another version
                 $excludeVersions += $packageVersion
                 Remove-Item -Path $package -Recurse -Force
                 continue

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -19,6 +19,7 @@
  .PARAMETER select
   Select the package to download if more than one package is found matching the name and version
   - Earliest: Select the earliest version
+  - EarliestMatching: Select the earliest version matching the already installed dependencies
   - Latest: Select the latest version (default)
   - LatestMatching: Select the latest version matching the already installed dependencies
   - Exact: Select the exact version
@@ -253,7 +254,7 @@ try {
                         throw $dependenciesErr
                     }
                     else {
-                        # If we are looking for the latest matching version, then we can try to find another version
+                            # If we are looking for the earliest/latest matching version, then we can try to find another version
                         Write-Host "WARNING: $dependenciesErr"
                         break
                     }
@@ -263,11 +264,11 @@ try {
                         # Downloading Microsoft packages for a specific version
                         $dependencyVersion = $version
                     }
-                    $returnValue += Download-BcNuGetPackageToFolder -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $dependencyId -version $dependencyVersion -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps+$returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
+                        $returnValue += Download-BcNuGetPackageToFolder -nuGetServerUrl $nuGetServerUrl -nuGetToken $nuGetToken -packageName $dependencyId -version $dependencyVersion -folder $package -copyInstalledAppsToFolder $copyInstalledAppsToFolder -installedPlatform $installedPlatform -installedCountry $installedCountry -installedApps @($installedApps + $returnValue) -downloadDependencies $downloadDependencies -verbose:($VerbosePreference -eq 'Continue') -select $select -allowPrerelease:$allowPrerelease -checkLocalVersion
                 }
             }
             if ($dependenciesErr) {
-                # If we are looking for the latest matching version, then we can try to find another version
+                    # If we are looking for the earliest/latest matching version, then we can try to find another version
                 $excludeVersions += $packageVersion
                 Remove-Item -Path $package -Recurse -Force
                 continue

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -57,7 +57,7 @@ Function Download-BcNuGetPackageToFolder {
         [Parameter(Mandatory=$false)]
         [string] $version = '0.0.0.0',
         [Parameter(Mandatory=$false)]
-        [ValidateSet('Earliest','Latest','LatestMatching','Exact','Any')]
+        [ValidateSet('Earliest','EarliestMatching','Latest','LatestMatching','Exact','Any')]
         [string] $select = 'Latest',
         [Parameter(Mandatory=$true)]
         [alias('appSymbolsFolder')]
@@ -80,6 +80,9 @@ try {
     $findSelect = $select
     if ($select -eq 'LatestMatching') {
         $findSelect = 'Latest'
+    }
+    if ($select -eq 'EarliestMatching') {
+        $findSelect = 'Earliest'
     }
     $excludeVersions = @()
     if ($checkLocalVersion) {
@@ -246,7 +249,7 @@ try {
                     Write-Host "WARNING: NuGet package $packageId (version $packageVersion) requires $dependencyCountry application. You have $installedCountry application installed"
                 }                   
                 if ($dependenciesErr) {
-                    if ($select -ne 'LatestMatching') {
+                    if (@('LatestMatching', 'EarliestMatching') -notcontains $select) {
                         throw $dependenciesErr
                     }
                     else {

--- a/NuGet/Publish-BcNuGetPackageToContainer.ps1
+++ b/NuGet/Publish-BcNuGetPackageToContainer.ps1
@@ -18,6 +18,7 @@
  .PARAMETER select
   Select the package to download if more than one package is found matching the name and version
   - Earliest: Select the earliest version
+  - EarliestMatching: Select the earliest version matching the already installed dependencies
   - Latest: Select the latest version (default)
   - LatestMatching: Select the latest version matching the already installed dependencies
   - Exact: Select the exact version
@@ -49,7 +50,7 @@ Function Publish-BcNuGetPackageToContainer {
         [Parameter(Mandatory=$false)]
         [string] $version = '0.0.0.0',
         [Parameter(Mandatory=$false)]
-        [ValidateSet('Earliest','Latest','LatestMatching','Exact','Any')]
+        [ValidateSet('Earliest', 'EarliestMatching', 'Latest', 'LatestMatching', 'Exact', 'Any')]
         [string] $select = 'Latest',
         [string] $containerName = "",
         [Hashtable] $bcAuthContext,

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Issue 3762 Give Option to Choose SQL PowerShell Module When Restoring From BacPac
 There are instances where sqlps does not work as expected when it is installed. This change adds a switch parameter, useSqlServerModule, to Restore-BcDatabaseFromArtifacts, New-NavContainer, and the BcContainerHelper config file.
 Issue 1303 from AL-Go repository - renew federated token when access token needs renewal (works only for GitHub at this time)
+Issue 3590 EarliestMatching select option added to Download-BcNuGetPackageToFolder
 
 6.0.29
 Issue 3591 When using Publish-NAVApp to publish an app, which fails compilation in the service, the command might hang forever - the fix for this is a temporary hack put in place for the versions which doesn't work.


### PR DESCRIPTION
For runtime creation / OnPrem deployments it's usually needed to retrieve runtime packages with the earliest matching version. This approach feels almost too easy so please point out if I missed something but it seemed to resolve the way I want it to.

#3590 