### PR TITLE
Fix for missing Label for platform on docker container

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -122,8 +122,14 @@ function Invoke-ScriptInBcContainer {
         }
         $shell = 'powershell'
         if ($usePwsh) {
-            [System.Version]$platformVersion = Get-BcContainerPlatformVersion -containerOrImageName $containerName
-            if ($platformVersion -ge [System.Version]"24.0.0.0") {
+            $platformVersion = Get-BcContainerPlatformVersion -containerOrImageName $containerName
+            if ("$platformVersion" -eq '') {
+                $platformVersion = (Get-BcContainerNavVersion -containerOrImageName $containerName).Split('-')[0]
+            }
+            if ($platformVersion -eq '') {
+                Write-Host "WARNING: Unable to get docker platform or version labels"
+            }
+            if ([System.Version]$platformVersion -ge [System.Version]"24.0.0.0") {
                 $shell = 'pwsh'
             }
         }


### PR DESCRIPTION
A minor fix that should be implemented in case of missing docker container Label `platform`.

`Get-BcContainerPlatformVersion` can return an empty string, which results in as a soft error, hard to track because it runs inside of container.

The error:
`Cannot convert value "" to type "System.Version". Error: "Version string portion was too short or too long. (Parameter 'input')"`

I tried to be consistent how you handle soft errors for `Get-BcContainerPlatformVersion`. I used `Get-BcContainerNavVersion` as a fallback and additionally added a warning to point the user in the right direction to fix it.