### PR TITLE
Extend condition to check for name and publisher

### DIFF
--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -209,7 +209,7 @@ try {
                         $dependencies += @{"publisher" = "Microsoft"; "name" = "Application"; "appId" = ''; "version" = $copyCompilerFolderApp.Application }
                     }
                 }
-                if (!($dependencies | where-Object { $_.Name -eq 'System'})) {
+                if (!($dependencies | where-Object { ($_.Name -eq "System") -and ($_.Publisher -eq "Microsoft") })) {
                     $dependencies += @{"publisher" = "Microsoft"; "name" = "System"; "appId" = ''; "version" = $copyCompilerFolderApp.Platform }
                 }
                 $addDependencies += $copyCompilerFolderApp.Dependencies
@@ -232,7 +232,7 @@ try {
         $depidx++
     }
 
-    $systemSymbolsApp = @($existingApps | Where-Object { $_.Name -eq "System" })
+        $systemSymbolsApp = @($existingApps | Where-Object { ($_.Name -eq "System") -and ($_.Publisher -eq "Microsoft") })
     if ($systemSymbolsApp.Count -ne 1) {
         throw "Unable to locate system symbols"
     }
@@ -277,7 +277,7 @@ try {
         }
         if (([bool]($appJsonObject.PSobject.Properties.name -eq "platform")) -and $appJsonObject.platform) {
             Write-Host "Platform Dependency $($appJsonObject.platform)"
-            $existingApps | Where-Object { $_.Name -eq "System" -and $_.Version -gt [System.Version]$appJsonObject.platform } | ForEach-Object {
+                $existingApps | Where-Object { $_.Name -eq "System" -and $_.Version -gt [System.Version]$appJsonObject.platform -and $_.Publisher -eq "Microsoft"} | ForEach-Object {
                 $appJsonObject.platform = "$($_.Version)"
                 Write-Host "- Set Platform dependency to $($_.Version)"
                 $changes = $true


### PR DESCRIPTION
We have the problem, that we have a app which is named "System" as well. The problem is that we get the following error when we use the funciton `Compile-AppWithBcCompilerFolder`: 
![image](https://github.com/user-attachments/assets/b08c5ec4-ee42-4673-b4f4-7af67871e475)

Therefore we need to also check the publisher of the dependency to avoid the error and wrong behaviour in the other places. 