### PR TITLE
CompilerFolder doesn't transfer installed Apps to NuGet resolution

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -482,8 +482,7 @@ try {
                         }
                     }
                     if ($throw) {
-                        Write-Host "ERROR $($_.Exception.Message)"
-                        throw (GetExtendedErrorMessage $_)
+                        throw "Error downloading symbols for $symbolsName. Error was: $($_.Exception.Message)"
                     }
                 }
                 if (Test-Path -Path $symbolsFile) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -508,7 +508,7 @@ function GetInstalledApps {
     Write-GroupStart -Message "Installed Apps"
     $installedApps | ForEach-Object {
         Write-Host "- $($_.AppId):$($_.Name)"
-        return @{ "AppId" = "$($_.AppId)"; "Name" = "$($_.Name)"; "Publisher" = "$($_.Publisher)"; "Version" = "$($_.Version)" }
+        return @{ "Id" = "$($_.AppId)"; "Name" = "$($_.Name)"; "Publisher" = "$($_.Publisher)"; "Version" = "$($_.Version)" }
     }
     Write-GroupEnd
 }
@@ -1458,7 +1458,7 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
+$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingAppDependencies) {
 Write-GroupStart -Message "Installing app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1633,7 +1633,7 @@ Write-GroupEnd
 
 if ((($testCountry) -or !($appFolders -or $testFolders -or $bcptTestFolders)) -and ($InstallMissingDependencies)) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1841,7 +1841,7 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -2695,7 +2695,7 @@ $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -files
 $testAppIds.Keys | ForEach-Object {
     $disabledTests = @()
     $id = $_
-    if ($installedApps.AppId -notcontains $id) {
+    if ($installedApps.Id -notcontains $id) {
         throw "App with $id is not installed, cannot run tests"
     }
     $folder = $testAppIds."$id"

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1485,6 +1485,7 @@ Measure-Command {
         "missingDependencies" = @($unknownAppDependencies | Where-Object { $missingAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
         "installedApps" = $installedApps
+        "installedCountry" = $artifactUrl.Substring($artifactUrl.LastIndexOf('/')+1)
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{
@@ -1659,6 +1660,7 @@ Measure-Command {
         "missingDependencies" = @($unknownTestAppDependencies | Where-Object { $missingTestAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
         "installedApps" = $installedApps
+        "installedCountry" = $artifactUrl.Substring($artifactUrl.LastIndexOf('/')+1)
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1489,6 +1489,11 @@ Measure-Command {
             "tenant" = $tenant
         }
     }
+    elseif($useCompilerFolder) {
+        $Parameters += @{
+            "compilerFolder" = (GetCompilerFolder)
+        }
+    }
     if ($generateDependencyArtifact -and !($testCountry)) {
         $parameters += @{
             "CopyInstalledAppsToFolder" = $dependenciesFolder
@@ -1498,7 +1503,7 @@ Measure-Command {
     if ($useCompilerFolder) {
         Write-Host "check $appSymbolsFolder"
         Get-ChildItem -Path $appSymbolsFolder | ForEach-Object {
-            Write-Host "Move $($_.Name)"
+            Write-Host "Move $($_.Name) to $packagesFolder"
             Move-Item -Path $_.FullName -Destination $packagesFolder -Force
             $appsBeforeApps += @(Join-Path $packagesFolder $_.Name)
         }

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -474,7 +474,7 @@ function UpdateLaunchJson {
 
 }
 
-function GetInstalledAppIds {
+function GetInstalledApps {
     Param(
         [bool] $useCompilerFolder,
         [string] $packagesFolder,
@@ -491,8 +491,10 @@ function GetInstalledAppIds {
         $installedApps = Get-ChildItem -Path (Join-Path $packagesFolder '*.app') | ForEach-Object {
             $appJson = Get-AppJsonFromAppFile -appFile $_.FullName
             return @{
-                "appId"                 = $appJson.id
-                "name"                  = $appJson.name
+                "AppId"                 = $appJson.id
+                "Name"                  = $appJson.name
+                "Publisher"             = $appJson.publisher
+                "Version"               = $appJson.version
             }
         }
     }
@@ -506,7 +508,7 @@ function GetInstalledAppIds {
     Write-GroupStart -Message "Installed Apps"
     $installedApps | ForEach-Object {
         Write-Host "- $($_.AppId):$($_.Name)"
-        "$($_.AppId)"
+        return @{ "AppId" = "$($_.AppId)"; "Name" = "$($_.Name)"; "Publisher" = "$($_.Publisher)"; "Version" = "$($_.Version)" }
     }
     Write-GroupEnd
 }
@@ -1455,8 +1457,8 @@ Write-GroupEnd
 }
 
 if ($InstallMissingDependencies) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
+$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
 if ($missingAppDependencies) {
 Write-GroupStart -Message "Installing app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1482,16 +1484,12 @@ Measure-Command {
     $Parameters = @{
         "missingDependencies" = @($unknownAppDependencies | Where-Object { $missingAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
+        "installedApps" = $installedApps
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{
             "containerName" = (GetBuildcontainer)
             "tenant" = $tenant
-        }
-    }
-    elseif($useCompilerFolder) {
-        $Parameters += @{
-            "compilerFolder" = (GetCompilerFolder)
         }
     }
     if ($generateDependencyArtifact -and !($testCountry)) {
@@ -1633,8 +1631,8 @@ Write-GroupEnd
 }
 
 if ((($testCountry) -or !($appFolders -or $testFolders -or $bcptTestFolders)) -and ($InstallMissingDependencies)) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1660,6 +1658,7 @@ Measure-Command {
     $Parameters = @{
         "missingDependencies" = @($unknownTestAppDependencies | Where-Object { $missingTestAppDependencies -contains "$_".Split(':')[0] })
         "appSymbolsFolder" = $appSymbolsFolder
+        "installedApps" = $installedApps
     }
     if (!($useCompilerFolder -or $filesOnly)) {
         $Parameters += @{
@@ -1839,8 +1838,8 @@ Measure-Command {
 Write-GroupEnd
 
 if ($InstallMissingDependencies) {
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedAppIds -notcontains $_ })
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
+$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.AppId -notcontains $_ })
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -2471,13 +2470,13 @@ if ($testCountry) {
     Write-Host -ForegroundColor Yellow "Publishing apps for additional country $testCountry"
 }
 
-$installedApps = @()
+$alreadyInstalledApps = @()
 if (!($bcAuthContext)) {
     $Parameters = @{
         "containerName" = (GetBuildContainer)
         "tenant" = $tenant
     }
-    $installedApps = Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters
+    $alreadyInstalledApps = Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters
 }
 
 $upgradedApps = @()
@@ -2490,7 +2489,7 @@ $apps | ForEach-Object {
         $appJson = [System.IO.File]::ReadAllLines($appJsonFile) | ConvertFrom-Json
         $upgradedApps += @($appJson.Id.ToLowerInvariant())
 
-        if ($installedApps | Where-Object { "$($_.AppId)" -eq $appJson.Id }) {
+        if ($alreadyInstalledApps | Where-Object { "$($_.AppId)" -eq $appJson.Id }) {
             $installedApp = $true
         }
     }
@@ -2690,11 +2689,11 @@ $testFolders | ForEach-Object {
     }
 }
 
-$installedAppIds = @(GetInstalledAppIds -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
+$installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
 $testAppIds.Keys | ForEach-Object {
     $disabledTests = @()
     $id = $_
-    if ($installedAppIds -notcontains $id) {
+    if ($installedApps.AppId -notcontains $id) {
         throw "App with $id is not installed, cannot run tests"
     }
     $folder = $testAppIds."$id"

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -229,10 +229,8 @@ try {
                     $installedApp = $installedApps | Where-Object { $_ -and $_.id -and $dependencyId -like "*$($_.id)*" }
                     if ($installedApp) {
                         # Dependency is already installed, check version number
-                        Write-Host "Dependency is already installed $($installedApp.Version), check version number $dependencyVersion"
                         if (!([NuGetFeed]::IsVersionIncludedInRange($installedApp.Version, $dependencyVersion))) {
                             # The version installed ins't compatible with the NuGet package found
-                            Write-Host "SET ERROR"
                             $dependenciesErr = "Dependency $dependencyId is already installed with version $($installedApp.Version), which is not compatible with the version $dependencyVersion required by the NuGet package $packageId (version $packageVersion))"
                         }
                     }

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -224,9 +224,6 @@ try {
                         $dependencyPublisher = $matches[1]
                         if ($dependencyPublisher -eq 'microsoft') {
                             $dependencyCountry = "$($matches[3])".TrimStart('.')
-                            if ($dependencyCountry -eq 'symbols') {
-                                $dependencyCountry = ''
-                            }
                         }
                     }
                     $installedApp = $installedApps | Where-Object { $_ -and $_.id -and $dependencyId -like "*$($_.id)*" }
@@ -249,6 +246,10 @@ try {
                     else {
                         $downloadIt = ($downloadDependencies -ne 'none')
                     }
+                }
+                # When downloading symbols, country will be symbols if no specific country is specified
+                if ($dependencyCountry -eq 'symbols') {
+                    $dependencyCountry = ''
                 }
                 if ($installedCountry -and $dependencyCountry -and ($installedCountry -ne $dependencyCountry)) {
                     # The NuGet package found isn't compatible with the installed application

--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -224,13 +224,18 @@ try {
                         $dependencyPublisher = $matches[1]
                         if ($dependencyPublisher -eq 'microsoft') {
                             $dependencyCountry = "$($matches[3])".TrimStart('.')
+                            if ($dependencyCountry -eq 'symbols') {
+                                $dependencyCountry = ''
+                            }
                         }
                     }
                     $installedApp = $installedApps | Where-Object { $_ -and $_.id -and $dependencyId -like "*$($_.id)*" }
                     if ($installedApp) {
                         # Dependency is already installed, check version number
+                        Write-Host "Dependency is already installed $($installedApp.Version), check version number $dependencyVersion"
                         if (!([NuGetFeed]::IsVersionIncludedInRange($installedApp.Version, $dependencyVersion))) {
                             # The version installed ins't compatible with the NuGet package found
+                            Write-Host "SET ERROR"
                             $dependenciesErr = "Dependency $dependencyId is already installed with version $($installedApp.Version), which is not compatible with the version $dependencyVersion required by the NuGet package $packageId (version $packageVersion))"
                         }
                     }

--- a/NuGet/Publish-BcNuGetPackageToContainer.ps1
+++ b/NuGet/Publish-BcNuGetPackageToContainer.ps1
@@ -90,7 +90,7 @@ Function Publish-BcNuGetPackageToContainer {
             }
             Publish-BcContainerApp -containerName $containerName -bcAuthContext $bcAuthContext -environment $environment -tenant $tenant -appFile $appFiles -sync -install -upgrade -checkAlreadyInstalled -skipVerification -copyInstalledAppsToFolder $copyInstalledAppsToFolder
         }
-        else {
+        elseif ($ErrorActionPreference -ne 'SilentlyContinue') {
             throw "No apps to publish"
         }
     }

--- a/NuGet/Publish-BcNuGetPackageToContainer.ps1
+++ b/NuGet/Publish-BcNuGetPackageToContainer.ps1
@@ -90,8 +90,11 @@ Function Publish-BcNuGetPackageToContainer {
             }
             Publish-BcContainerApp -containerName $containerName -bcAuthContext $bcAuthContext -environment $environment -tenant $tenant -appFile $appFiles -sync -install -upgrade -checkAlreadyInstalled -skipVerification -copyInstalledAppsToFolder $copyInstalledAppsToFolder
         }
-        elseif ($ErrorActionPreference -ne 'SilentlyContinue') {
+        elseif ($ErrorActionPreference -eq 'Stop') {
             throw "No apps to publish"
+        }
+        else {
+            Write-Host "No apps to publish"
         }
     }
     finally {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,7 @@
 6.0.35
 AL-Go issue 1288 Library apps are not installed if only referenced from test apps
+AL-Go issue 1330 CompilerFolder doesn't transfer installed Apps to NuGet resolution
+AL-Go issue 1268 Do not throw an un-understandable error during nuGet download
 
 6.0.34
 Compare files before giving a warning about apps with the same name in Run-AlPipeline


### PR DESCRIPTION
This PR is the BcContainerHelper part of making sure that the installed apps, the platform and the country are transferred to NuGet resolution when locating apps for downloading - making sure that you don't download a package with dependencies to BC which is newer than what you are building for.

It is a requirement for https://github.com/microsoft/AL-Go/pull/1450
