### PR TITLE
Add retry logic for Ingestion API 503 and 504 HTTP status codes.

### DIFF
--- a/AppSource/Invoke-IngestionAPI.ps1
+++ b/AppSource/Invoke-IngestionAPI.ps1
@@ -73,7 +73,10 @@ function Invoke-IngestionApiRestMethod {
                 }
                 catch {}
 
-                if ($retries -gt 0 -and $statusCode -eq 500) {
+                # 500 Internal Server Error
+                # 503 Service Unavailable
+                # 504 Gateway Timeout
+                if ($retries -gt 0 -and $statusCode -in @(500, 503, 504)) {}
                     $retries--
                     Write-Host "$(GetExtendedErrorMessage $_)".TrimEnd()
                     Write-Host "...retrying in $waittime minute(s)"


### PR DESCRIPTION
Add retry logic for Ingestion API status codes:
 - 503 - Service Unavailable
 - 504 - Gateway Timeout