### PR TITLE
Apps, which only are published are included in installedapps

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -504,8 +504,9 @@ function GetInstalledApps {
         $Parameters = @{
             "containerName" = (GetBuildContainer)
             "tenant" = $tenant
+            "tenantSpecificProperties" = $true
         }
-        $installedApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters)
+        $installedApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { -not $_.IsInstalled })
     }
     Write-GroupStart -Message "Installed Apps"
     $installedApps | ForEach-Object {
@@ -2492,8 +2493,9 @@ if (!($bcAuthContext)) {
     $Parameters = @{
         "containerName" = (GetBuildContainer)
         "tenant" = $tenant
+        "tenantSpecificProperties" = $true
     }
-    $alreadyInstalledApps = Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters
+    $alreadyInstalledApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { -not $_.IsInstalled })
 }
 
 $upgradedApps = @()

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -506,7 +506,7 @@ function GetInstalledApps {
             "tenant" = $tenant
             "tenantSpecificProperties" = $true
         }
-        $installedApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { -not $_.IsInstalled })
+        $installedApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { $_.IsInstalled })
     }
     Write-GroupStart -Message "Installed Apps"
     $installedApps | ForEach-Object {
@@ -2495,7 +2495,7 @@ if (!($bcAuthContext)) {
         "tenant" = $tenant
         "tenantSpecificProperties" = $true
     }
-    $alreadyInstalledApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { -not $_.IsInstalled })
+    $alreadyInstalledApps = @(Invoke-Command -ScriptBlock $GetBcContainerAppInfo -ArgumentList $Parameters | Where-Object { $_.IsInstalled })
 }
 
 $upgradedApps = @()

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Issue 3882 Run-AlPipeline with CompilerFolder and Container defined fails when running tests
 Allow running tests in online sandboxes, using CompilerFolder (and ConnectFromHost)
 Add parameter appName to Run-TestsInBcContainer to specify the name of an app in Test Results, if not specified when running against online sandboxes, the appid will be used.
+During Run-AlPipeline, apps which are only published are reported as being installed, which leads to error 1530 in AL-Go repository
 
 6.1.3
 Add setting ExcludeBuilds, which is an array of NuGet range specifications to exclude from Get-BcArtifactUrl. See more about range specification here: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges


### PR DESCRIPTION
During Run-AlPipeline, apps which are only published are reported as being installed, which leads to error 1530 in AL-Go repository