### PR TITLE
Update dvd paths to handle new folder layout with Wix 6 msi builder.

### DIFF
--- a/Artifacts/Download-Artifacts.ps1
+++ b/Artifacts/Download-Artifacts.ps1
@@ -257,7 +257,7 @@ try {
                             }
                         }
                         $ad1DLL = Join-Path $platformArtifactPath 'Applications\testframework\TestRunner\Internal\Microsoft.IdentityModel.Clients.ActiveDirectory.dll'
-                        $ad2DLL = Join-Path $platformArtifactPath 'ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Management\Microsoft.IdentityModel.Clients.ActiveDirectory.dll'
+                        $ad2DLL = Join-Path $platformArtifactPath 'ServiceTier\*\Microsoft Dynamics NAV\*\Service\Management\Microsoft.IdentityModel.Clients.ActiveDirectory.dll'
                         if ((Test-Path $ad1DLL) -and (Test-Path $ad2DLL)) {
                             if ((Get-Item $ad1DLL).Length -ne (Get-Item $ad2DLL).Length) {
                                 Write-Host "INFO: Patching wrong version of Microsoft.IdentityModel.Clients.ActiveDirectory.dll in $ad1DLL"

--- a/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
+++ b/Bacpac/Restore-BcDatabaseFromArtifacts.ps1
@@ -67,9 +67,9 @@ try {
             Write-Host "Downloading Artifacts $($artifactUrl.Split('?')[0])"
             $artifactPath = Download-Artifacts $artifactUrl -includePlatform
             
-            $ManagementModule = Get-Item -Path (Join-Path $artifactPath[1] "ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.dll")
+            $ManagementModule = Get-Item -Path (Join-Path $artifactPath[1] "ServiceTier\*\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Management.dll")
             if (!($ManagementModule)) {
-                $ManagementModule = Get-Item -Path (Join-Path $artifactPath[1] "ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Management\Microsoft.Dynamics.Nav.Management.dll")
+                $ManagementModule = Get-Item -Path (Join-Path $artifactPath[1] "ServiceTier\*\Microsoft Dynamics NAV\*\Service\Management\Microsoft.Dynamics.Nav.Management.dll")
                 if (!($ManagementModule)) {
                     throw "Unable to locate management module in artifacts"
                 }

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -84,7 +84,7 @@ try {
         $artifactPaths = Download-Artifacts -artifactUrl $artifactUrl -includePlatform
         $appArtifactPath = $artifactPaths[0]
         $platformArtifactPath = $artifactPaths[1]
-        $newtonSoftDllPath = Join-Path $platformArtifactPath "ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll" -Resolve
+        $newtonSoftDllPath = Join-Path $platformArtifactPath "ServiceTier\*\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll" -Resolve
     }
 
     # IncludeAL will populate folder with AL files (like New-BcContainer)
@@ -115,14 +115,14 @@ try {
         New-Item $compilerPath -ItemType Directory | Out-Null
         New-Item $dllsPath -ItemType Directory | Out-Null
         # Enumerate subfolders to ensure we support different casings in folder structure
-        $modernDevFolder = Join-Path $platformArtifactPath "ModernDev\program files\Microsoft Dynamics NAV\*\AL Development Environment"
+        $modernDevFolder = Join-Path $platformArtifactPath "ModernDev\*\Microsoft Dynamics NAV\*\AL Development Environment"
         $modernDevFolder = Get-ChildItem -Recurse -Directory -Path $platformArtifactPath | Where-Object { $_.FullName -like $modernDevFolder } | ForEach-Object { $_.FullName }
         Copy-Item -Path (Join-Path $modernDevFolder 'System.app') -Destination $symbolsPath
         if ($cacheFolder -or !$vsixFile) {
             # Only unpack the artifact vsix file if we are populating a cache folder - or no vsixFile was specified
             Expand-7zipArchive -Path (Join-Path $modernDevFolder 'ALLanguage.vsix') -DestinationPath $compilerPath
         }
-        $serviceTierFolder = Join-Path $platformArtifactPath "ServiceTier\program files\Microsoft Dynamics NAV\*\Service" -Resolve
+        $serviceTierFolder = Join-Path $platformArtifactPath "ServiceTier\*\Microsoft Dynamics NAV\*\Service" -Resolve
         Copy-Item -Path $serviceTierFolder -Filter '*.dll' -Destination $dllsPath -Recurse
         $newtonSoftDllPath = Join-Path $dllsPath "Newtonsoft.Json.dll"
         Remove-Item -Path (Join-Path $dllsPath 'Service\Management') -Recurse -Force -ErrorAction SilentlyContinue

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -954,7 +954,7 @@ try {
             $navVersion = $dvdVersion
         }
         else {
-            $navversion = (Get-Item -Path "$dvdPath\ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Server.exe").VersionInfo.FileVersion
+            $navversion = (Get-Item -Path "$dvdPath\ServiceTier\*\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Server.exe").VersionInfo.FileVersion
         }
         $navtag = Get-NavVersionFromVersionInfo -VersionInfo $navversion
         if ("$navtag" -eq "" -and "$dvdPlatform" -eq "") {

--- a/ContainerHandling/New-NavImage.ps1
+++ b/ContainerHandling/New-NavImage.ps1
@@ -510,7 +510,13 @@ try {
                 RobocopyFiles -source "$platformArtifactPath" -destination "$navDvdPath" -e
         
                 if (!$skipDatabase) {
-                    $dbPath = Join-Path $navDvdPath "SQLDemoDatabase\CommonAppData\Microsoft\Microsoft Dynamics NAV\ver\Database"
+                    $CommonData = "CommonData"
+                    if ($appManifest.version -lt [Version]"27.0.0.0")
+                    {
+                        $CommonData = "CommonAppData"
+                    }
+
+                    $dbPath = Join-Path $navDvdPath "SQLDemoDatabase\$CommonData\Microsoft\Microsoft Dynamics NAV\ver\Database"
                     New-Item $dbPath -ItemType Directory | Out-Null
                     if (($databaseBackupPath) -and (Test-Path $databaseBackupPath -PathType Leaf))
                     {


### PR DESCRIPTION
Add support for the new dvd folder layout in version 27 due to the change to Wix 6 msi builder. The dvd folders now uses tokenized names and not the real Windows names (like pfiles64 and not "Program Files"),