### PR TITLE
Handle empty installedApps during InstallMissingDependencies

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1464,7 +1464,7 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+if ($installedApps) {
     $missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 }
 if ($missingAppDependencies) {
@@ -1644,7 +1644,7 @@ Write-GroupEnd
 
 if ((($testCountry) -or !($appFolders -or $testFolders -or $bcptTestFolders)) -and ($InstallMissingDependencies)) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
-if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+if ($installedApps) {
     $missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 }
 if ($missingTestAppDependencies) {
@@ -1857,7 +1857,7 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+if ($installedApps) {
     $missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
 }
 if ($missingTestAppDependencies) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1464,7 +1464,9 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+    $missingAppDependencies = @($missingAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+}
 if ($missingAppDependencies) {
 Write-GroupStart -Message "Installing app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1642,7 +1644,9 @@ Write-GroupEnd
 
 if ((($testCountry) -or !($appFolders -or $testFolders -or $bcptTestFolders)) -and ($InstallMissingDependencies)) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -compilerFolder (GetCompilerFolder) -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+    $missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+}
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'
@@ -1853,7 +1857,9 @@ Write-GroupEnd
 
 if ($InstallMissingDependencies) {
 $installedApps = @(GetInstalledApps -useCompilerFolder $useCompilerFolder -filesOnly $filesOnly -packagesFolder $packagesFolder)
-$missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+if ($null -ne $installedApps -and $installedApps.Count -gt 0) {
+    $missingTestAppDependencies = @($missingTestAppDependencies | Where-Object { $installedApps.Id -notcontains $_ })
+}
 if ($missingTestAppDependencies) {
 Write-GroupStart -Message "Installing test app dependencies"
 Write-Host -ForegroundColor Yellow @'


### PR DESCRIPTION
Run-AlPipeline will fail during InstallMissingDependencies if there are no apps installed. In [BCApps](https://github.com/microsoft/BCApps) we uninstall all apps during NewBCContainer since we need to publish and install a new System App, Business Foundation etc. 

```
Error: Unexpected error when running action. Error Message: The property 'Id' cannot be found on this object. Verify that the 
property exists., StackTrace: at <ScriptBlock>, C:\ProgramData\BcContainerHelper\6.1.4-
preview1309\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 1467 <- at <ScriptBlock>, 
C:\ProgramData\BcContainerHelper\6.1.4-preview1309\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 1467 <- at 
<ScriptBlock>, C:\ProgramData\BcContainerHelper\6.1.4-preview1309\BcContainerHelper\AppHandling\Run-AlPipeline.ps1: line 
1270 <- at Run-AlPipeline, C:\ProgramData\BcContainerHelper\6.1.4-preview1309\BcContainerHelper\AppHandling\Run-
AlPipeline.ps1: line 1255 <- at <ScriptBlock>, D:\a\_actions\microsoft\AL-
Go\120540b15626528818b0aca52dc4822eb527e5c4\Actions\RunPipeline\RunPipeline.ps1: line 397 <- at <ScriptBlock>, 
D:\a\_temp\a32e8248-1300-4804-b08b-4c68719b71bb.ps1: line 3 <- at <ScriptBlock>, D:\a\_actions\microsoft\AL-
Go\120540b15626528818b0aca52dc4822eb527e5c4\Actions\Invoke-AlGoAction.ps1: line 17 <- at <ScriptBlock>, 
D:\a\_temp\a32e8248-1300-4804-b08b-4c68719b71bb.ps1: line 2 <- at <ScriptBlock>, <No file>: line 1
```

This recently started failing. Likely related to this fix: https://github.com/microsoft/navcontainerhelper/commit/a60d3b004e404db2a0569cc49ef2c2b2c8177c90