### PR TITLE
Don't remove packagesFolder if it already exists

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -875,10 +875,9 @@ if ($updateLaunchJson) {
 
 if ($useCompilerFolder -or $filesOnly -or !$useDevEndpoint) {
     $packagesFolder = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $packagesFolder -name "packagesFolder"
-    if (Test-Path $packagesFolder) {
-        Remove-Item $packagesFolder -Recurse -Force
+    if (!(Test-Path $packagesFolder)) {
+        New-Item $packagesFolder -ItemType Directory | Out-Null
     }
-    New-Item $packagesFolder -ItemType Directory | Out-Null
 }
 
 if ($useDevEndpoint) {

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -875,9 +875,12 @@ if ($updateLaunchJson) {
 
 if ($useCompilerFolder -or $filesOnly -or !$useDevEndpoint) {
     $packagesFolder = CheckRelativePath -baseFolder $baseFolder -sharedFolder $sharedFolder -path $packagesFolder -name "packagesFolder"
-    if (!(Test-Path $packagesFolder)) {
-        New-Item $packagesFolder -ItemType Directory | Out-Null
+    if (!($bcContainerHelperConfig.doNotRemovePackagesFolderIfExists)) {
+        if (Test-Path $packagesFolder) {
+            Remove-Item $packagesFolder -Recurse -Force
+        }
     }
+    New-Item $packagesFolder -ItemType Directory -Force | Out-Null 
 }
 
 if ($useDevEndpoint) {

--- a/BC.HelperFunctions.ps1
+++ b/BC.HelperFunctions.ps1
@@ -122,6 +122,7 @@ function Get-ContainerHelperConfig {
             "useApproximateVersion" = $false
             "useSqlServerModule" = $false
             "NuGetSearchResultsCacheRetentionPeriod" = 600 # 10 minutes
+            "doNotRemovePackagesFolderIfExists" = $false
         }
 
         if ($isInsider) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,7 @@ Fixes issues determining test symbols for W1 and OnPrem artifacts not containing
 Add cache for search results of a NuGet feed
 Add new setting NuGetSearchResultsCacheRetentionPeriod (default: 600) to set the retention period (in seconds) for the search result cache of NuGet feeds (0 to disable the cache)
 Download-BcNuGetPackageToFolder checks all direct dependency versions of a package based on the NuSpec before downloading the whole package and its dependencies
+New Option doNotRemovePackagesFolderIfExists to prevent Run-ALPipeline from deleting the packages folder, if it already exists. Default is false
 
 6.1.3
 Add setting ExcludeBuilds, which is an array of NuGet range specifications to exclude from Get-BcArtifactUrl. See more about range specification here: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges


### PR DESCRIPTION
If compilefolders are used the packages folder will be deleted and recreated during the pipeline run.

In certain cases especially when you use customized AL:Go with foreign container systems, this folder exists on purpose and already includes files. This files should not be deleted because it will lead the pipeline to fail