### PR TITLE
fail early if app.json isn't valid

### DIFF
--- a/AppHandling/Sort-AppFoldersByDependencies.ps1
+++ b/AppHandling/Sort-AppFoldersByDependencies.ps1
@@ -56,7 +56,9 @@ try {
         }
         else {
             $appJson =[System.IO.File]::ReadAllLines($appJsonFile) | ConvertFrom-Json
-            
+            if (-not $appJson) {
+                throw "$appJsonFile isn't a valid json file."
+            }
             # replace id with appid
             if ($appJson.psobject.Members | Where-Object name -eq "dependencies") {
                 if ($appJson.dependencies) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 6.1.5
 Include AuthContext and Environment in Parameters for InstallMissingDependencies when called from Run-AlPipeline
+AL-Go issue 1695 Fail early if app.json cannot be read
 
 6.1.4
 Issue 3882 Run-AlPipeline with CompilerFolder and Container defined fails when running tests


### PR DESCRIPTION
Give a better error in a situation like https://github.com/microsoft/AL-Go/issues/1695
