### PR TITLE
Load Analyzers\Microsoft.Dynamics.Nav.Analyzers.Common.dll when analyzers are enabled

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -648,6 +648,15 @@ try {
         if ($GenerateReportLayoutParam) {
             $alcParameters += @($GenerateReportLayoutParam)
         }
+
+        # Microsoft.Dynamics.Nav.Analyzers.Common.dll needs to referenced first, as this is how the analyzers are loaded
+        if ($EnableCodeCop -or $EnableAppSourceCop -or $EnablePerTenantExtensionCop -or $EnableUICop) {
+            $analyzersCommonDLLPath = Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.Analyzers.Common.dll'
+            if (Test-Path $analyzersCommonDLLPath) {
+                $alcParameters += @("/analyzer:$(Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.Analyzers.Common.dll')")
+            }
+        }
+
         if ($EnableCodeCop) {
             $alcParameters += @("/analyzer:$(Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.CodeCop.dll')")
         }

--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -352,7 +352,7 @@ try {
             $alcExe = 'alc'
             $alcCmd = "./$alcExe"
         }
-    }   
+    }
 
     if (!(Test-Path -Path (Join-Path $alcPath $alcExe))) {
         $alcCmd = "dotnet"
@@ -367,6 +367,15 @@ try {
     if ($GenerateReportLayoutParam) {
         $alcParameters += @($GenerateReportLayoutParam)
     }
+
+    # Microsoft.Dynamics.Nav.Analyzers.Common.dll needs to referenced first, as this is how the analyzers are loaded
+    if ($EnableCodeCop -or $EnableAppSourceCop -or $EnablePerTenantExtensionCop -or $EnableUICop) {
+        $analyzersCommonDLLPath = Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.Analyzers.Common.dll'
+        if (Test-Path $analyzersCommonDLLPath) {
+            $alcParameters += @("/analyzer:$(Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.Analyzers.Common.dll')")
+        }
+    }
+
     if ($EnableCodeCop) {
         $alcParameters += @("/analyzer:$(Join-Path $binPath 'Analyzers\Microsoft.Dynamics.Nav.CodeCop.dll')")
     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 6.1.5
 Include AuthContext and Environment in Parameters for InstallMissingDependencies when called from Run-AlPipeline
 AL-Go issue 1695 Fail early if app.json cannot be read
+Issue with BC artifact 27.0.33668.0: app compilation fails because of analyzers not being loaded properly
 
 6.1.4
 Issue 3882 Run-AlPipeline with CompilerFolder and Container defined fails when running tests
@@ -102,7 +103,7 @@ Include AI Toolkit when copying symbols from container
 Issue 3714 Download-BcNuGetPackageToFolder - throws error when use "-select Exact"
 Issue 3621 New-AadAppsForBc shows "-includeEmailAadApp is deprecated. Use -includeOtherServicesAadApp instead." but includeOtherServicesAadApp us not setting email permissions
 Issue 3718 Business Central Web Client Fails to Load After Updating to Windows 24H2
-Issue #3703 Missing Function Download-BcEnvironmentInstalledExtensionToFolder    
+Issue #3703 Missing Function Download-BcEnvironmentInstalledExtensionToFolder
 Fix for issue 1262 in AL-Go for GitHub
 Fix instabilities during Publish-PerTenantExtensionApps
 


### PR DESCRIPTION
Issue on BCApps: https://github.com/microsoft/BCApps/actions/runs/14808100532/job/41579351870?pr=3632

>  AL1003 An instance of analyzer Microsoft.Dynamics.Nav.CodeCop.Design.PermissionSetExtensionsShouldNotIncludePermissionsForObjectsFromDifferentApplication cannot be created from C:\ProgramData\BcContainerHelper\compiler\1fd7c862-d6e2-4d8e-8d0b-e2ab8f172466\compiler\extension\bin\Analyzers\Microsoft.Dynamics.Nav.CodeCop.dll : Could not load file or assembly 'Microsoft.Dynamics.Nav.Analyzers.Common, Version=16.0.22.33136, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. The system cannot find the file specified.