### PR TITLE
Limit assembly probing paths to a specific dotnet version when compiling in a container 

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -188,20 +188,26 @@ try {
                     }
 
                     $dotNetRuntimeVersionInstalled = ""
-                    $dotNetSharedFolder = 'C:\Program Files\dotnet\shared'
-                    if (Test-Path $dotNetSharedFolder) {
-                        $netCoreAppFolder = Join-Path $dotNetSharedFolder 'Microsoft.NETCore.App'
-                        if (Test-Path $netCoreAppFolder) {
-                            $versions = Get-ChildItem $netCoreAppFolder | ForEach-Object {
-                                try {
-                                    if (Test-Path (Join-Path $dotNetSharedFolder "Microsoft.AspNetCore.App/$($_.Name)")) {
-                                        [System.Version] $_.Name
+
+                    if ($platformversion.Major -ge 27) {
+                        # A change in the compiler in version 27 and later requires dotnet, used for assembly probing paths, to be version 8 (but not 9 or later)
+                        $dotnetRequiredMajorVersion = 8
+
+                        $dotNetSharedFolder = 'C:\Program Files\dotnet\shared'
+                        if (Test-Path $dotNetSharedFolder) {
+                            $netCoreAppFolder = Join-Path $dotNetSharedFolder 'Microsoft.NETCore.App'
+                            if (Test-Path $netCoreAppFolder) {
+                                $versions = Get-ChildItem $netCoreAppFolder | ForEach-Object {
+                                    try {
+                                        if (Test-Path (Join-Path $dotNetSharedFolder "Microsoft.AspNetCore.App/$($_.Name)")) {
+                                            [System.Version] $_.Name
+                                        }
+                                    }
+                                    catch {
                                     }
                                 }
-                                catch {
-                                }
+                                $dotNetRuntimeVersionInstalled = $versions | Where-Object { $_.Major -eq $dotnetRequiredMajorVersion } | Sort-Object -Descending | Select-Object -First 1
                             }
-                            $dotNetRuntimeVersionInstalled = $versions | Where-Object { $_.Major -ne 9 } | Sort-Object -Descending | Select-Object -First 1
                         }
                     }
 

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -188,7 +188,7 @@ try {
                     }
 
                     $assemblyProbingPaths += """$dotnetAssembliesFolder"""
-                    $assemblyProbingPaths = """C:\Program Files\dotnet\shared"",$assemblyProbingPaths"
+                    $assemblyProbingPaths = """C:\Program Files\dotnet\shared\Microsoft.NETCore.App\$dotNetRuntimeVersionInstalled"",""C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$dotNetRuntimeVersionInstalled"",$assemblyProbingPaths"
                 }
                 else {
                     $assemblyProbingPaths += """$serviceTierFolder"",""C:\Program Files (x86)\Open XML SDK\V2.5\lib"""

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -156,7 +156,7 @@ try {
     $containerFolder = Get-BcContainerPath -containerName $containerName -path (Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$containerName")
     if (!$PSBoundParameters.ContainsKey("assemblyProbingPaths")) {
         if ($platformversion.Major -ge 13) {
-            $assemblyProbingPaths = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($containerFolder, $appProjectFolder, $platformVersion)
+            $assemblyProbingPaths = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($containerFolder, $appProjectFolder, $platformVersion, $dotNetRuntimeVersionInstalled)
                 $assemblyProbingPaths = ""
                 $netpackagesPath = Join-Path $appProjectFolder ".netpackages"
                 if (Test-Path $netpackagesPath) {
@@ -199,7 +199,7 @@ try {
                     }
                 }
                 $assemblyProbingPaths
-            } -ArgumentList $containerFolder, $containerProjectFolder, $platformversion
+            } -ArgumentList $containerFolder, $containerProjectFolder, $platformversion, $dotNetRuntimeVersionInstalled
         }
     }
 


### PR DESCRIPTION
Limit assembly probing paths to a specific dotnet version when compiling in a container 