### PR TITLE
Add cache control during releases

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -252,7 +252,7 @@ jobs:
           
             Compress-Archive -path $path -DestinationPath "$($path).zip"
             Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "$version-$prerelease.zip" -Force | Out-Null
-            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "preview.zip" -Force | Out-Null
+            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "preview.zip" -Properties @{"CacheControl" = "no-cache"} -Force | Out-Null
           
             Write-Host "Publishing Module"
             Publish-Module -Path $path -NuGetApiKey '${{ secrets.NugetKey }}' -SkipAutomaticTags

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -108,9 +108,8 @@ jobs:
             New-AzStorageContainer -Name 'public' -Context $storageContext -Permission 'Container' -ErrorAction Ignore | Out-Null
           
             Compress-Archive -path $path -DestinationPath "$($path).zip"
-            $cacheDurationSeconds = 3600 # 1 hour
             Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "$version.zip" -Force | Out-Null
-            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "latest.zip" -Properties @{"CacheControl" = "max-age=$cacheDurationSeconds"} -Force | Out-Null
+            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "latest.zip" -Properties @{"CacheControl" = "no-cache"} -Force | Out-Null
             
             Write-Host "Publishing Module"
             Publish-Module -Path $path -NuGetApiKey '${{ secrets.NugetKey }}' -SkipAutomaticTags

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -108,8 +108,9 @@ jobs:
             New-AzStorageContainer -Name 'public' -Context $storageContext -Permission 'Container' -ErrorAction Ignore | Out-Null
           
             Compress-Archive -path $path -DestinationPath "$($path).zip"
+            $cacheDurationSeconds = 3600 # 1 hour
             Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "$version.zip" -Force | Out-Null
-            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "latest.zip" -Force | Out-Null
+            Set-AzStorageBlobContent -File "$($path).zip" -Context $storageContext -Container 'public' -Blob "latest.zip" -Properties @{"CacheControl" = "max-age=$cacheDurationSeconds"} -Force | Out-Null
             
             Write-Host "Publishing Module"
             Publish-Module -Path $path -NuGetApiKey '${{ secrets.NugetKey }}' -SkipAutomaticTags


### PR DESCRIPTION
When releasing bccontainerhelper we upload the new version to a storage account. When these blobs are accessed through AFD we should specify what the cache duration should be so AFD takes that into consideration.