### PR TITLE
Update Get-AlLanguageExtensionFromArtifacts such that it supports NextMajor artifacts

### DIFF
--- a/ContainerHandling/Get-AlLanguageExtensionFromArtifacts.ps1
+++ b/ContainerHandling/Get-AlLanguageExtensionFromArtifacts.ps1
@@ -15,7 +15,7 @@ $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -paramet
 try {
 
     $paths = Download-Artifacts $artifactUrl -includePlatform
-    $vsixFile = Get-Item -Path (Join-Path $paths[1] "ModernDev\program files\Microsoft Dynamics NAV\*\AL Development Environment\*.vsix")
+    $vsixFile = Get-Item -Path (Join-Path $paths[1] "ModernDev\*\Microsoft Dynamics NAV\*\AL Development Environment\*.vsix")
     if ($vsixFile) {
         $vsixFile.FullName
     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 6.1.7
+Issue 3952 Get-AlLanguageExtensionFromArtifacts fails on new BC artifacts
 
 6.1.6
 Added a new outcome to failOn = newWarning. For BcContainerHelper it will work as error - in AL-Go for GitHub it will have a meaning.


### PR DESCRIPTION
In NextMajor the path has changed from ModenDev/Program Files to ModernDev/pffiles. Update Get-AlLanguageExtensionFromArtifacts such that it supports NextMajor artifacts. 

Fixes #3952