### PR TITLE
Fix package ID length adjustment logic in Get-BcNuGetPackageId function

### DIFF
--- a/NuGet/Get-BcNuGetPackageId.ps1
+++ b/NuGet/Get-BcNuGetPackageId.ps1
@@ -49,8 +49,8 @@ function Get-BcNuGetPackageId {
     # Max. Length of NuGet Package Id is 100 - we shorten the name part of the id if it is too long
     $packageId = $packageIdTemplate.replace('{name}',$nname)
     if ($packageId.Length -gt 100) {
-        if ($nname.Length -gt ($packageId.Length - 99)) {
-            $nname = $nname.Substring(0, $nname.Length - ($packageId.Length - 99))
+        if ($nname.Length -gt ($packageId.Length - 100)) {
+            $nname = $nname.Substring(0, $nname.Length - ($packageId.Length - 100))
         }
         else {
             throw "Package id is too long: $packageId, unable to shorten it"


### PR DESCRIPTION
The `Get-BcNuGetPackageId` function causes an issue when working with the **DynamicsBCPublicFeeds** for **AppSource Symbols**.

Although the maximum allowed length for a NuGet Package ID is **100 characters**, the function currently truncates the ID to **99 characters**. This leads to a **mismatch** with the actual package IDs published in the `AppSourceSymbols` feed, which use the full 100-character length.

## Example

| | |
|------|-------------|
| **1. Original** | `TRASERSoftwareGmbH.TRASERECMConnect365xShareflexDocuments.symbols.c909c76e-7140-4e34-ba8e-7b47a8fe0247` *(101 characters)* |
| **2. Output from `Get-BcNuGetPackageId`** | `TRASERSoftwareGmbH.TRASERECMConnect365xShareflexDocume.symbols.c909c76e-7140-4e34-ba8e-7b47a8fe0247` *(99 characters)* |
| **3. Actual in AppSourceSymbols** | `TRASERSoftwareGmbH.TRASERECMConnect365xShareflexDocumen.symbols.c909c76e-7140-4e34-ba8e-7b47a8fe0247` *(100 characters)* |

## Impact

This one-character mismatch leads to **failed package resolution** with the Feed.

**DynamicsBCPublicFeeds:** https://dynamicssmb2.visualstudio.com/DynamicsBCPublicFeeds/_artifacts/feed/AppSourceSymbols