### PR TITLE
Disable failing tests due to the error on missing ODBC driver of older NAV versions

### DIFF
--- a/Tests/AppHandling (NAV).Tests.ps1
+++ b/Tests/AppHandling (NAV).Tests.ps1
@@ -15,6 +15,7 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
 Describe 'AppHandling' -Skip {
 
     It 'Add-GitToAlProjectFolder' {

--- a/Tests/AppHandling (NAV).Tests.ps1
+++ b/Tests/AppHandling (NAV).Tests.ps1
@@ -15,7 +15,7 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+Describe 'AppHandling' -Skip {
 
     It 'Add-GitToAlProjectFolder' {
         #TODO

--- a/Tests/Bacpac (MT).Tests.ps1
+++ b/Tests/Bacpac (MT).Tests.ps1
@@ -12,7 +12,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveBcContainer.ps1')
 }
 
-Describe 'Bacpac' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'Bacpac' -Skip {
 
     It 'Export-NavContainerDatabasesAsBacpac (multitenant)' {
 

--- a/Tests/Bacpac (NAV).Tests.ps1
+++ b/Tests/Bacpac (NAV).Tests.ps1
@@ -12,7 +12,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'Bacpac' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'Bacpac' -Skip {
 
     It 'Backup-NavContainerDatabases' {
 
@@ -23,7 +24,7 @@ Describe 'Bacpac' {
                                      -bakFolder $bakFolder
 
         $bakFile | Should -Exist
-                
+
         New-NavContainer -accept_eula `
                          -accept_outdated `
                          -artifactUrl $navArtifactUrl `

--- a/Tests/GetAndRunTests (version 10).Tests.ps1
+++ b/Tests/GetAndRunTests (version 10).Tests.ps1
@@ -16,7 +16,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'AppHandling' -Skip{
 
     It 'Get/RunTests' {
         $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
@@ -38,7 +39,7 @@ Describe 'AppHandling' {
 
         $tests = (Get-TestsFromNavContainer -containerName $navContainerName -credential $credential).Codeunits
         $tests.Count | Should -be 2
-    
+
         $first = $true
         $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$navContainerName\result.xml"
         $tests | % {

--- a/Tests/GetAndRunTests (version 11).Tests.ps1
+++ b/Tests/GetAndRunTests (version 11).Tests.ps1
@@ -16,7 +16,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'AppHandling' -Skip {
 
     It 'Get/RunTests' {
         $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
@@ -38,7 +39,7 @@ Describe 'AppHandling' {
 
         $tests = (Get-TestsFromNavContainer -containerName $navContainerName -credential $credential).Codeunits
         $tests.Count | Should -be 2
-    
+
         $first = $true
         $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$navContainerName\result.xml"
         $tests | % {

--- a/Tests/GetAndRunTests (version 14).Tests.ps1
+++ b/Tests/GetAndRunTests (version 14).Tests.ps1
@@ -16,7 +16,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'AppHandling' -Skip {
 
     It 'Get/RunTests' {
         $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
@@ -37,7 +38,7 @@ Describe 'AppHandling' {
 
         $tests = (Get-TestsFromNavContainer -containerName $navContainerName -credential $credential).Codeunits
         $tests.Count | Should -be 2
-    
+
         $first = $true
         $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$navContainerName\result.xml"
         $tests | % {

--- a/Tests/GetAndRunTests (version 9).Tests.ps1
+++ b/Tests/GetAndRunTests (version 9).Tests.ps1
@@ -16,7 +16,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'AppHandling' -Skip {
 
     It 'Get/RunTests' {
         $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
@@ -38,7 +39,7 @@ Describe 'AppHandling' {
 
         $tests = (Get-TestsFromNavContainer -containerName $navContainerName -credential $credential).Codeunits
         $tests.Count | Should -be 2
-    
+
         $first = $true
         $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$navContainerName\result.xml"
         $tests | % {

--- a/Tests/ObjectHandling (NAV).Tests.ps1
+++ b/Tests/ObjectHandling (NAV).Tests.ps1
@@ -17,7 +17,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'ObjectHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'ObjectHandling' -Skip {
 
     It 'Import-ObjectsToNavContainer (.txt)' {
         Import-ObjectsToNavContainer -containerName $navContainerName `

--- a/Tests/TenantHandling.Tests.ps1
+++ b/Tests/TenantHandling.Tests.ps1
@@ -12,7 +12,8 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveBcContainer.ps1')
 }
 
-Describe 'TenantHandling' {
+# Test is disabled because of an error with missing ODBC driver when importing .fob files (supported only on older versions of NAV)
+Describe 'TenantHandling' -Skip {
 
     It 'Get-BcContainerTenants' {
         Get-BcContainerTenants -containerName $bcContainerName | Should -Not -BeNullOrEmpty


### PR DESCRIPTION
The skipped tests are failing due to the error on missing ODBC driver (needed to support .fob files import for older NAV versions)

Test run: https://github.com/microsoft/navcontainerhelper/actions/runs/16145608366