### PR TITLE
introducing RequiredTestIsolation filter 

### DIFF
--- a/AppHandling/Get-TestsFromNavContainer.ps1
+++ b/AppHandling/Get-TestsFromNavContainer.ps1
@@ -20,6 +20,8 @@
   Name of test suite to get. Default is DEFAULT.
  .Parameter ExtensionId
   Specify an extensionId to get all tests in the app.
+ .PARAMETER requiredTestIsolation
+  Specify the required test isolation level. Get all tests if not specified.
  .Parameter testType
   Specify the type of tests to get. Get all tests if not specified.
  .Parameter testCodeunit
@@ -70,6 +72,8 @@ function Get-TestsFromBcContainer {
         [Parameter(Mandatory=$false)]
         [string] $testCodeunitRange = "",
         [string] $extensionId = "",
+        [Parameter(Mandatory=$false)]
+        [string] $requiredTestIsolation = "",
         [Parameter(Mandatory=$false)]
         [string] $testType = "",
         [array]  $disabledTests = @(),
@@ -186,7 +190,7 @@ try {
         }
     } -argumentList "01:00:00"
 
-    $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh ($version.Major -ge 26) -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testCodeunit, [string] $testCodeunitRange, [string] $PsTestFunctionsPath, [string] $ClientContextPath, $testPage, $version, $culture, $timezone, $debugMode, $ignoreGroups, $usePublicWebBaseUrl, $useUrl, $extensionId, $testType, $disabledtests)
+    $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh ($version.Major -ge 26) -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [pscredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testCodeunit, [string] $testCodeunitRange, [string] $PsTestFunctionsPath, [string] $ClientContextPath, $testPage, $version, $culture, $timezone, $debugMode, $ignoreGroups, $usePublicWebBaseUrl, $useUrl, $extensionId, $requiredTestIsolation, $testType, $disabledtests)
     
         $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
         if (!(Test-Path $newtonSoftDllPath)) {
@@ -244,6 +248,7 @@ try {
                       -TestCodeunit $testCodeunit `
                       -testCodeunitRange $testCodeunitRange `
                       -ExtensionId $extensionId `
+                      -RequiredTestIsolation $requiredTestIsolation `
                       -TestType $testType `
                       -DisabledTests $disabledtests `
                       -testPage $testPage `
@@ -266,7 +271,7 @@ try {
             }
         }
 
-    } -argumentList $tenant, $companyName, $profile, $credential, $accessToken, $testSuite, $testCodeunit, $testCodeunitRange, (Get-BCContainerPath -containerName $containerName -path $PsTestFunctionsPath), (Get-BCContainerPath -containerName $containerName -path $ClientContextPath), $testPage, $version, $culture, $timezone, $debugMode, $ignoreGroups, $usePublicWebBaseUrl, $useUrl, $extensionId, $testType, $disabledtests
+    } -argumentList $tenant, $companyName, $profile, $credential, $accessToken, $testSuite, $testCodeunit, $testCodeunitRange, (Get-BCContainerPath -containerName $containerName -path $PsTestFunctionsPath), (Get-BCContainerPath -containerName $containerName -path $ClientContextPath), $testPage, $version, $culture, $timezone, $debugMode, $ignoreGroups, $usePublicWebBaseUrl, $useUrl, $extensionId, $requiredTestIsolation, $testType, $disabledtests
 
     # When Invoke-ScriptInContainer is running as non-administrator - Write-Host (like license warnings) are send to the output
     # If the output is an array - grab the last item.

--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -106,6 +106,29 @@ function Set-ExtensionId
     $ClientContext.SaveValue($extensionIdControl, $ExtensionId)
 }
 
+function Set-RequiredTestIsolation
+(
+    [ValidateSet('None','Disabled','Codeunit','Function')]
+    [string] $RequiredTestIsolation,
+    [ClientContext] $ClientContext,
+    [switch] $debugMode,
+    $Form
+)
+{
+    if ($debugMode) {
+        Write-Host "Setting Required Test Isolation $RequiredTestIsolation"
+    }
+
+    $TestIsolationValues = @{
+        None = 0
+        Disabled = 1
+        Codeunit = 2
+        Function = 3
+    }
+    $requiredTestIsolationControl = $ClientContext.GetControlByName($Form, "RequiredTestIsolation")
+    $ClientContext.SaveValue($requiredTestIsolationControl, $TestIsolationValues[$RequiredTestIsolation])
+}
+
 function Set-TestType
 (
     [ValidateSet('UnitTest','IntegrationTest','Uncategorized')]
@@ -355,6 +378,7 @@ function Get-Tests {
         [string] $testCodeunit = "*",
         [string] $testCodeunitRange = "",
         [string] $extensionId = "",
+        [string] $requiredTestIsolation = "",
         [string] $testType = "",
         [string] $testRunnerCodeunitId = "",
         [array]  $disabledtests = @(),
@@ -396,6 +420,9 @@ function Get-Tests {
 
     if ($testPage -eq 130455) {
         Set-ExtensionId -ExtensionId $extensionId -Form $form -ClientContext $clientContext -debugMode:$debugMode
+        if (![string]::IsNullOrEmpty($requiredTestIsolation)) {
+            Set-RequiredTestIsolation -RequiredTestIsolation $requiredTestIsolation -Form $form -ClientContext $clientContext -debugMode:$debugMode
+        }
         if (![string]::IsNullOrEmpty($testType)) {
             Set-TestType -TestType $testType -Form $form -ClientContext $clientContext -debugMode:$debugMode
         }
@@ -551,6 +578,7 @@ function Run-Tests {
         [string] $testGroup = "*",
         [string] $testFunction = "*",
         [string] $extensionId = "",
+        [string] $requiredTestIsolation = "",
         [string] $testType = "",
         [string] $appName = "",
         [string] $testRunnerCodeunitId,
@@ -616,6 +644,9 @@ function Run-Tests {
 
     if ($testPage -eq 130455) {
         Set-ExtensionId -ExtensionId $extensionId -Form $form -ClientContext $clientContext -debugMode:$debugMode
+        if (![string]::IsNullOrEmpty($requiredTestIsolation)) {
+            Set-RequiredTestIsolation -RequiredTestIsolation $requiredTestIsolation -Form $form -ClientContext $clientContext -debugMode:$debugMode
+        }
         if (![string]::IsNullOrEmpty($testType)) {
             Set-TestType -TestType $testType -Form $form -ClientContext $clientContext -debugMode:$debugMode
         }

--- a/AppHandling/Run-TestsInNavContainer.ps1
+++ b/AppHandling/Run-TestsInNavContainer.ps1
@@ -32,7 +32,9 @@
  .Parameter testFunction
   Name of test function to run. Wildcards (? and *) are supported. Default is *.
  .Parameter ExtensionId
-  Specifying an extensionId causes the test tool to run all tests in the app with this app id.
+  Specifying an extensionId causes the test tool to run all tests in the app with this app id.\
+ .PARAMETER requiredTestIsolation
+  Specify the required test isolation level. This is used to filter the tests that are run.
  .Parameter testType
   Specify the type of tests to run. This is used to filter the tests that are run.
  .Parameter appName
@@ -115,6 +117,8 @@ function Run-TestsInBcContainer {
         [Parameter(Mandatory=$false)]
         [string] $testFunction = "*",
         [string] $extensionId = "",
+        [Parameter(Mandatory=$false)]
+        [string] $requiredTestIsolation = "",
         [Parameter(Mandatory=$false)]
         [string] $testType = "",
         [string] $appName = "",
@@ -400,6 +404,7 @@ try {
                               -TestCodeunitRange $testCodeunitRange `
                               -TestFunction $testFunction `
                               -ExtensionId $extensionId `
+                              -RequiredTestIsolation $requiredTestIsolation `
                               -TestType $testType `
                               -appName $appName `
                               -TestRunnerCodeunitId $testRunnerCodeunitId `
@@ -443,7 +448,7 @@ try {
                     }
                 }
 
-                $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh ($version.Major -ge 26) -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [System.Management.Automation.PSCredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testGroup, [string] $testCodeunit, [string] $testCodeunitRange, [string] $testFunction, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [string] $XUnitResultFileName, [bool] $AppendToXUnitResultFile, [string] $JUnitResultFileName, [bool] $AppendToJUnitResultFile, [bool] $ReRun, [string] $AzureDevOps, [string] $GitHubActions, [bool] $detailed, [timespan] $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $testType, $appName, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests)
+                $result = Invoke-ScriptInBcContainer -containerName $containerName -usePwsh ($version.Major -ge 26) -scriptBlock { Param([string] $tenant, [string] $companyName, [string] $profile, [System.Management.Automation.PSCredential] $credential, [string] $accessToken, [string] $testSuite, [string] $testGroup, [string] $testCodeunit, [string] $testCodeunitRange, [string] $testFunction, [string] $PsTestFunctionsPath, [string] $ClientContextPath, [string] $XUnitResultFileName, [bool] $AppendToXUnitResultFile, [string] $JUnitResultFileName, [bool] $AppendToJUnitResultFile, [bool] $ReRun, [string] $AzureDevOps, [string] $GitHubActions, [bool] $detailed, [timespan] $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $requiredTestIsolation, $testType, $appName, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests)
     
                     $newtonSoftDllPath = "C:\Program Files\Microsoft Dynamics NAV\*\Service\Management\Newtonsoft.Json.dll"
                     if (!(Test-Path $newtonSoftDllPath)) {
@@ -524,6 +529,7 @@ try {
                                   -TestCodeunitRange $testCodeunitRange `
                                   -TestFunction $testFunction `
                                   -ExtensionId $extensionId `
+                                  -RequiredTestIsolation $requiredTestIsolation `
                                   -TestType $testType `
                                   -appName $appName `
                                   -TestRunnerCodeunitId $testRunnerCodeunitId `
@@ -552,7 +558,7 @@ try {
                         }
                     }
             
-                } -argumentList $tenant, $companyName, $profile, $credential, $accessToken, $testSuite, $testGroup, $testCodeunit, $testCodeunitRange, $testFunction, (Get-BcContainerPath -containerName $containerName -Path $PsTestFunctionsPath), (Get-BCContainerPath -containerName $containerName -path $ClientContextPath), $containerXUnitResultFileName, $AppendToXUnitResultFile, $containerJUnitResultFileName, $AppendToJUnitResultFile, $ReRun, $AzureDevOps, $GitHubActions, $detailed, $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $testType, $appName, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests.IsPresent
+                } -argumentList $tenant, $companyName, $profile, $credential, $accessToken, $testSuite, $testGroup, $testCodeunit, $testCodeunitRange, $testFunction, (Get-BcContainerPath -containerName $containerName -Path $PsTestFunctionsPath), (Get-BCContainerPath -containerName $containerName -path $ClientContextPath), $containerXUnitResultFileName, $AppendToXUnitResultFile, $containerJUnitResultFileName, $AppendToJUnitResultFile, $ReRun, $AzureDevOps, $GitHubActions, $detailed, $interactionTimeout, $testPage, $version, $culture, $timezone, $debugMode, $usePublicWebBaseUrl, $useUrl, $extensionId, $requiredTestIsolation, $testType, $appName, $testRunnerCodeunitId, $disabledtests, $renewClientContextBetweenTests.IsPresent
             }
             if ($result -is [array]) {
                 0..($result.Count-2) | % { Write-Host $result[$_] }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -2,6 +2,7 @@
 Issue 3952 Get-AlLanguageExtensionFromArtifacts fails on new BC artifacts
 Add support for TestType field when running tests
 Issue 3943 Error downloading symbols for Microsoft_System
+Add support for RequiredTestIsolation field when running tests
 
 6.1.6
 Added a new outcome to failOn = newWarning. For BcContainerHelper it will work as error - in AL-Go for GitHub it will have a meaning.


### PR DESCRIPTION
Allow filter tests by `RequiredTestIsolation` in CI pipeline, related to https://github.com/microsoft/BCApps/pull/4137