### PR TITLE
Adding option to remove only containers created by AL-Go.

### DIFF
--- a/ContainerHandling/Flush-ContainerHelperCache.ps1
+++ b/ContainerHandling/Flush-ContainerHelperCache.ps1
@@ -63,8 +63,19 @@ try {
                     $exitedDaysAgo = [DateTime]::Now.Subtract($finishedAt).Days
                     if ($exitedDaysAgo -ge $keepDays) {
                         if (($inspect.Config.Labels.psobject.Properties.Match('maintainer').Count -ne 0 -and $inspect.Config.Labels.maintainer -eq "Dynamics SMB")) {
-                            Write-Host "Removing container $containerName"
-                            docker rm $containerID -f
+                            if ($caches.Contains('ALGoContainersOnly')) {
+                                if ($inspect.Config.Labels.psobject.Properties.Match('creator').Count -ne 0 -and $inspect.Config.Labels.creator -eq "AL-Go") {
+                                    Write-Host "Removing container $containerName"
+                                    docker rm $containerID -f
+                                } 
+                                else {
+                                    Write-Host "Container $containerName (exited $exitedDaysAgo day$(if($exitedDaysAgo -ne 1){'s'}) ago) is recognized as a Business Central Container, but was not created by AL-Go - not removing"
+                                }
+                            } 
+                            else {
+                                Write-Host "Removing container $containerName"
+                                docker rm $containerID -f
+                            }   
                         }
                         else {
                             Write-Host "Container $containerName (exited $exitedDaysAgo day$(if($exitedDaysAgo -ne 1){'s'}) ago) is not recognized as a Business Central Container - not removing"


### PR DESCRIPTION
Related to AL-Go issue: https://github.com/microsoft/AL-Go/issues/1675
During the AL-Go CICD workflow, we will purge all containers Business Central containers created via navcontainerhelper, if they have been offline for 3 days (by default). 
This scenario can happen if you have containers on a VM as well as self-hosted GitHub runners used for AL-Go, as those runners will purge both the containers created by AL-Go, but also any other BC containers on that VM which might have been creator for other purposes.
This fix allows a new option to the cache param of the Flush function, such that it checks for a AL-Go creator label and only deleted containers with that label. A separate PR on the AL-Go side, will add this label to containers created by AL-Go.