### PR TITLE
Disable hanging test for 9.0

### DIFF
--- a/Tests/GetAndRunTests (version 9).Tests.ps1
+++ b/Tests/GetAndRunTests (version 9).Tests.ps1
@@ -16,7 +16,7 @@ AfterAll {
     . (Join-Path $PSScriptRoot '_RemoveNavContainer.ps1')
 }
 
-Describe 'AppHandling' {
+Describe 'AppHandling' -Skip {
 
     It 'Get/RunTests' {
         $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
@@ -53,4 +53,5 @@ Describe 'AppHandling' {
         }
         $resultsFile | Should -Exist
     }
+
 }


### PR DESCRIPTION
Disable hanging test for 9.0

Test is timing out: https://github.com/microsoft/navcontainerhelper/actions/runs/17041322422/attempts/1

Underlying issue likely related to Issue 3994