### PR TITLE
Update Extract-AppFileToFolder to handle Ready-2-Run apps 

### DIFF
--- a/AppHandling/Extract-AppFileToFolder.ps1
+++ b/AppHandling/Extract-AppFileToFolder.ps1
@@ -85,7 +85,7 @@ try {
         $zipArchive = [System.IO.Compression.ZipArchive]::new($memoryStream, [System.IO.Compression.ZipArchiveMode]::Read)
         $prevdir = ""
 
-        # If the app file is a ready-to-run app, it have a readytorunappmanifest.json file inside the archive
+        # If the app file is a ready-to-run app, it has a readytorunappmanifest.json file inside the archive
         $readyToRunAppManifest = $zipArchive.Entries | Where-Object { $_.FullName -eq "readytorunappmanifest.json" }
         if ($readyToRunAppManifest) {
             # Create a temporary folder to extract the ready-to-run app manifest
@@ -104,6 +104,11 @@ try {
             # Create a temporary folder to extract the app file to
             $fullname = Join-Path $tmpFolder ([Uri]::UnescapeDataString($embeddedAppFile.FullName))
             [System.IO.Compression.ZipFileExtensions]::ExtractToFile($embeddedAppFile, $fullname)
+
+            # Close stream and binary reader before recursive call
+            $binaryReader.Close()
+            $filestream.Close()
+            $memoryStream.Close()
 
             try {
                 # Call the Extract-AppFileToFolder function again to extract the content of the app file

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -2925,13 +2925,18 @@ $pageScriptingTests | ForEach-Object {
     Write-Host "Running Page Scripting Tests for $testSpec (test name: $name)"
     $resultsFolder = Join-Path $pageScriptingTestResultsFolder $name
     New-Item -Path $resultsFolder -ItemType Directory | Out-Null
-    pwsh -command {
-        npx replay $args[0] -ResultDir $args[1] -StartAddress $args[2] -Authentication UserPassword -usernameKey 'containerUsername' -passwordkey 'containerPassword'
+    $thisFailed = pwsh -command {
+        try {
+            npx replay $args[0] -ResultDir $args[1] -StartAddress $args[2] -Authentication UserPassword -usernameKey 'containerUsername' -passwordkey 'containerPassword'
+        } catch {
+            Write-Host "Error running page scripting test $($args[0]) - $($_.Exception.Message)"
+            return $true
+        }
+        return $false
     } -args $path, $resultsFolder, $startAddress
-    if ($? -ne "True") {
+    if ($thisFailed) {
         Write-Host "Page Scripting Tests failed for $testSpec"
         $allPassed = $false
-        $thisFailed = $true
     }
     $testResultsFile = Join-Path $resultsFolder "results.xml"
     $playwrightReportFolder = Join-Path $resultsFolder 'playwright-report'

--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -2922,7 +2922,7 @@ $pageScriptingTests | ForEach-Object {
     $path = $testSpec
     if (-not [System.IO.Path]::IsPathRooted($path)) { $path = Join-Path $baseFolder $path }
     if (-not (Test-Path $path)) { throw "No page scripting tests found matching $testSpec" }
-    Write-Host "(TEST) Running Page Scripting Tests for $testSpec (test name: $name)"
+    Write-Host "Running Page Scripting Tests for $testSpec (test name: $name)"
     $resultsFolder = Join-Path $pageScriptingTestResultsFolder $name
     New-Item -Path $resultsFolder -ItemType Directory | Out-Null
     try {


### PR DESCRIPTION
With the introduction of Ready-2-Run apps the format of the .app files has been slightly changed. Before, the content of an app file looked like this: 
 
<img width="426" height="199" alt="image" src="https://github.com/user-attachments/assets/0a826d7a-d39d-4d4e-940b-92169df23168" />

Now it looks like this:
<img width="510" height="137" alt="image" src="https://github.com/user-attachments/assets/70fce051-0427-458d-8ff7-39673538586d" />

Where the embedded app file is the "real" app file. 

To handle this, I'm adding a recursive call to Extract-AppFileToFolder in case it is a ready-2-run app. 

Related to #4001