### PR TITLE
Fix: non small/lower letters used in Flush-ContainerHelperCache comparison.

### DIFF
--- a/ContainerHandling/Flush-ContainerHelperCache.ps1
+++ b/ContainerHandling/Flush-ContainerHelperCache.ps1
@@ -63,9 +63,9 @@ try {
                     $exitedDaysAgo = [DateTime]::Now.Subtract($finishedAt).Days
                     if ($exitedDaysAgo -ge $keepDays) {
                         if (($inspect.Config.Labels.psobject.Properties.Match('maintainer').Count -ne 0 -and $inspect.Config.Labels.maintainer -eq "Dynamics SMB")) {
-                            if ($caches.Contains('ALGoContainersOnly')) {
+                            if ($caches.Contains('algocontainersonly')) {
                                 if ($inspect.Config.Labels.psobject.Properties.Match('creator').Count -ne 0 -and $inspect.Config.Labels.creator -eq "AL-Go") {
-                                    Write-Host "Removing container $containerName"
+                                    Write-Host "Removing AL-Go container $containerName"
                                     docker rm $containerID -f
                                 } 
                                 else {


### PR DESCRIPTION
Small fix to a comparison in Flush-ContainerHelperCache where a non-lower string is compared to the input cache, but the input cache is forced to always be lower letters.