### PR TITLE
Add error logging in Download-File

### DIFF
--- a/Common/Download-File.ps1
+++ b/Common/Download-File.ps1
@@ -82,10 +82,11 @@ function Download-File {
                 if ($_.Exception.Message -like '*404*' -or $waitTime -gt 60) {
                     throw (GetExtendedErrorMessage $_)
                 }
-                Write-Host "Error downloading..., retrying in $waitTime seconds..."
+                Write-Host "Error downloading, error: $($_)... Retrying in $waitTime seconds..."
                 Start-Sleep -Seconds $waitTime
             }
         }
     }
 }
 Export-ModuleMember -Function Download-File
+


### PR DESCRIPTION
This pull request makes a minor improvement to the error logging in the `Download-File` function. The change enhances the error message by including the actual error details when a download fails and a retry is attempted.

* Improved error logging in `Download-File` to display the specific error encountered before retrying.