### PR TITLE
Stop trying to fetch applicationversion from v27+ databases 

### DIFF
--- a/AppHandling/Clean-BcContainerDatabase.ps1
+++ b/AppHandling/Clean-BcContainerDatabase.ps1
@@ -307,4 +307,4 @@ finally {
     TrackTrace -telemetryScope $telemetryScope
 }
 }
-Export-ModuleMember -Function Clean-BcContainerDatabase2
+Export-ModuleMember -Function Clean-BcContainerDatabase

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -349,7 +349,7 @@ try {
     }
 
     $applicationApp = $publishedApps | Where-Object { $_.publisher -eq "Microsoft" -and $_.name -eq "Application" }
-    if (-not $applicationApp) {
+    if ((-not $applicationApp) -and ($platformversion -lt [System.Version]"27.0.0.0")) {
         # locate application version number in database if using SQLEXPRESS
         try {
             if (($customConfig.DatabaseServer -eq "localhost") -and ($customConfig.DatabaseInstance -eq "SQLEXPRESS")) {

--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -349,7 +349,7 @@ try {
     }
 
     $applicationApp = $publishedApps | Where-Object { $_.publisher -eq "Microsoft" -and $_.name -eq "Application" }
-    if ((-not $applicationApp) -and ($platformversion -lt [System.Version]"27.0.0.0")) {
+    if ((-not $applicationApp) -and ($platformversion -le [System.Version]"26.0.0.0")) {
         # locate application version number in database if using SQLEXPRESS
         try {
             if (($customConfig.DatabaseServer -eq "localhost") -and ($customConfig.DatabaseInstance -eq "SQLEXPRESS")) {

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 6.1.8
 AL-Go issue 1920 Pagescript not working on own github runner
+Issue 4018 Using New-navcontainer with useNewDatabase=true for BC 27 fails
 
 6.1.7
 Issue 3952 Get-AlLanguageExtensionFromArtifacts fails on new BC artifacts


### PR DESCRIPTION
With v27 the applicationVersion is gone from the $ndo$dbproperty table. There are a couple of places in BCContainerHelper where we try to fetch the application version from this property. We'll need to update that.

Related to: #4018