### PR TITLE
Temporarily avoid using dotnet 10 for assemblyProbingPaths

### DIFF
--- a/InitializeModule.ps1
+++ b/InitializeModule.ps1
@@ -59,7 +59,7 @@ if ($isWindows) {
                 catch {
                 }
             }
-            $dotNetRuntimeVersionInstalled = $versions | Where-Object { $_.Major -ne 9 } | Sort-Object -Descending | Select-Object -First 1
+            $dotNetRuntimeVersionInstalled = $versions | Where-Object { ($_.Major -ne 9) -and ($_.Major -ne 10) } | Sort-Object -Descending | Select-Object -First 1
         }
     }
 }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,6 @@
 6.1.11
+Temporarily avoid using dotnet 10 for assemblyProbingPaths
+
 
 6.1.10
 Better performance when downloading NuGet packages by adding another cache folder, which defaults to c:\bcnuget.cache


### PR DESCRIPTION
Temporarily avoid using dotnet 10 for assemblyProbingPaths due to compatibility issues 