### PR TITLE
Fix strict mode issue in Download-BcNuGetPackageToFolder

### DIFF
--- a/NuGet/Download-BcNuGetPackageToFolder.ps1
+++ b/NuGet/Download-BcNuGetPackageToFolder.ps1
@@ -78,6 +78,7 @@ Function Download-BcNuGetPackageToFolder {
     )
 
 try {
+    $returnValue = @()
     $findSelect = $select
     if ($select -eq 'LatestMatching') {
         $findSelect = 'AllDescending'
@@ -341,3 +342,4 @@ catch {
 }
 Set-Alias -Name Copy-BcNuGetPackageToFolder -Value Download-BcNuGetPackageToFolder
 Export-ModuleMember -Function Download-BcNuGetPackageToFolder -Alias Copy-BcNuGetPackageToFolder
+


### PR DESCRIPTION
Init return variable

if no $nuGetVersions is found the return variable is never initialized which results in a strict mode error

```
Looking for NuGet package *** version [10.2.300560.0,10.2.300560.1) (LatestMatching match)
Error Message: The variable '$returnValue' cannot be retrieved because it has not been set.
StackTrace: at Download-BcNuGetPackageToFolder, C:\Users\ContainerAdministrator\Documents\WindowsPowerShell\Modules\bccontainerhelper\6.1.10\NuGet\Download-BcNuGetPackageToFolder.ps1: line 335
```
Used to work with bcch 6.1.9, error since 6.1.10