### PR TITLE
Enhance PublishToPSGallery script with repository verification and detailed logging

### DIFF
--- a/.azuredevops/scripts/PublishToPSGallery.ps1
+++ b/.azuredevops/scripts/PublishToPSGallery.ps1
@@ -29,13 +29,25 @@ try {
     # Publish to PowerShell Gallery
     # Ensure the default repository is registered, PSGallery
     if (-not (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue)) {
+        Write-Host "PSGallery repository not found. Registering..."
         Register-PSRepository -Default
     }
-    Publish-Module -Path $ModulePath -NuGetApiKey $ApiKey -SkipAutomaticTags
+    
+    # Verify PSGallery is properly configured
+    $psGallery = Get-PSRepository -Name 'PSGallery' -ErrorAction Stop
+    Write-Host "PSGallery repository found:"
+    Write-Host "  SourceLocation: $($psGallery.SourceLocation)"
+    Write-Host "  PublishLocation: $($psGallery.PublishLocation)"
+    Write-Host "  InstallationPolicy: $($psGallery.InstallationPolicy)"
+    
+    # Publish to PowerShell Gallery with explicit repository name
+    Write-Host "Publishing module from: $ModulePath"
+    Publish-Module -Path $ModulePath -NuGetApiKey $ApiKey -Repository 'PSGallery' -SkipAutomaticTags -Verbose
 
     Write-Host "Successfully published to PowerShell Gallery"
 }
 catch {
     Write-Host "##vso[task.logissue type=error]Error publishing to PowerShell Gallery. Error was $($_.Exception.Message)"
+    Write-Host "##vso[task.logissue type=error]Full error details: $($_.Exception | Format-List * -Force | Out-String)"
     exit 1
 }


### PR DESCRIPTION
This pull request improves the PowerShell script used to publish modules to the PowerShell Gallery by adding better repository verification, enhanced logging, and more explicit publishing commands. These changes make the publishing process more robust and easier to troubleshoot.

Enhancements to publishing process:

* Added checks and log messages to verify that the `PSGallery` repository is registered and properly configured before publishing.
* Modified the `Publish-Module` command to explicitly specify the `PSGallery` repository and enabled verbose output for better visibility during publishing.

Improvements to error handling and diagnostics:

* Enhanced error handling by logging full error details when publishing fails, making troubleshooting easier.