### PR TITLE
Fix: Update PSGallery registration to specify source and publish location

### DIFF
--- a/.azuredevops/scripts/PublishToPSGallery.ps1
+++ b/.azuredevops/scripts/PublishToPSGallery.ps1
@@ -30,16 +30,16 @@ try {
     # Ensure the default repository is registered, PSGallery
     if (-not (Get-PSRepository -Name 'PSGallery' -ErrorAction SilentlyContinue)) {
         Write-Host "PSGallery repository not found. Registering..."
-        Register-PSRepository -Default
+        Register-PSRepository -Name 'PSGallery' -SourceLocation 'https://www.powershellgallery.com/api/v2/' -PublishLocation 'https://www.powershellgallery.com/api/v2/package/' -InstallationPolicy "Trusted"
     }
-    
+
     # Verify PSGallery is properly configured
     $psGallery = Get-PSRepository -Name 'PSGallery' -ErrorAction Stop
     Write-Host "PSGallery repository found:"
     Write-Host "  SourceLocation: $($psGallery.SourceLocation)"
     Write-Host "  PublishLocation: $($psGallery.PublishLocation)"
     Write-Host "  InstallationPolicy: $($psGallery.InstallationPolicy)"
-    
+
     # Publish to PowerShell Gallery with explicit repository name
     Write-Host "Publishing module from: $ModulePath"
     Publish-Module -Path $ModulePath -NuGetApiKey $ApiKey -Repository 'PSGallery' -SkipAutomaticTags -Verbose


### PR DESCRIPTION
This pull request makes a small but important update to the PowerShell script responsible for publishing to PSGallery. The change ensures that the PSGallery repository is registered with explicit source and publish locations, and sets the installation policy to "Trusted" for improved reliability.

* Explicitly registers the `PSGallery` repository with specific source and publish URLs, and sets installation policy to "Trusted" in `.azuredevops/scripts/PublishToPSGallery.ps1`.