### PR TITLE
Fix: Update PublishToPSGallery script to use module manifest for publishing

### DIFF
--- a/.azuredevops/scripts/PublishToPSGallery.ps1
+++ b/.azuredevops/scripts/PublishToPSGallery.ps1
@@ -40,8 +40,13 @@ try {
     Write-Host "  Trusted: $($psGallery.Trusted)"
 
     # Publish to PowerShell Gallery with explicit repository name
-    Write-Host "Publishing module from: $ModulePath"
-    Publish-PSResource -Path $ModulePath -ApiKey $ApiKey -Repository 'PSGallery' -SkipModuleManifestValidate -Verbose
+    # Use the specific module manifest to avoid publishing nested/sub-modules
+    $moduleManifestPath = Join-Path $ModulePath 'BcContainerHelper.psd1'
+    if (-not (Test-Path $moduleManifestPath)) {
+        throw "Module manifest not found at: $moduleManifestPath"
+    }
+    Write-Host "Publishing module from: $ModulePath (manifest: $moduleManifestPath)"
+    Publish-PSResource -Path $moduleManifestPath -ApiKey $ApiKey -Repository 'PSGallery' -SkipModuleManifestValidate -Verbose
 
     Write-Host "Successfully published to PowerShell Gallery"
 }


### PR DESCRIPTION
This pull request updates the publishing process for the PowerShell module to ensure only the intended main module is published, rather than any nested or sub-modules. The script now explicitly references the main module manifest and adds a check to confirm its existence before publishing.

Improvements to publishing process:

* The script now uses the specific `BcContainerHelper.psd1` module manifest when publishing, preventing accidental inclusion of nested or sub-modules. It also checks for the manifest's existence and throws an error if it's missing, improving reliability and clarity in the publishing workflow.