### PR TITLE
[Bug]: Run-BCPTTestsInBcContainer ends with error "Unable to load one or more of the requested types"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+### ❔What, Why & How
+
+<!-- Include description of the changes that will help reviewers in their task -->
+
+Related to issue: #
+
+### ✅ Checklist
+
+- [ ] Add tests (`Tests` / `LinuxTests`)
+- [ ] Update ReleaseNotes.txt
+- [ ] Add telemetry
+
+<!-- Include more checklist entries, if needed -->

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -6,8 +6,10 @@ Run-BCPTTestsInBcContainer: fix ends with error "Unable to load one or more of t
 Temporarily avoid using dotnet 10 for assemblyProbingPaths
 Issue 3986 Endless loop when errors occur during the execution of AL tests with external environments
 Issue 3986 Execution of AL tests fails for test codeunits without test functions
+Issue 4062 Error "Unable to load one or more of the requested types" when running tests on newer Artifacts having version 2.2. of Microsoft.Internal.AntiSSRF.dll 
 Get-BCArtifactUrl: Add Support for -before and -after Parameters in NextMinor and NextMajor
 Publish-PerTenantExtensionApps: Add support to unpublish previously installed apps after upgrade
+
 
 6.1.10
 Better performance when downloading NuGet packages by adding another cache folder, which defaults to c:\bcnuget.cache


### PR DESCRIPTION
Same issue as pointed out in #4062 

Adding type resolver when loading AntiSSRF dll for dll version 2.2. When trying to add the AntiSSRF dll, the dependency on `System.Threading.Tasks.Extensions` is not automatically found since it's not in a standard location. This fix preloads it, so it's always available.

This appears to only be a problem in PowerShell 5 (PS5). PowerShell 7 (PS7) does work (I believe the threading dll is pre-loaded in the runtime), but for AL-Go and anyone else that needs to use PS5 this is a required fix.

Regarding AL-Go, we can't switch to PS7 since the current way the test runner handles disabling SSL is not compatible with .Net Core used in PS7.
https://github.com/microsoft/navcontainerhelper/blob/main/HelperFunctions.ps1 already has a method for both versions for dealing with SSL, but the test runner was made a long ago and would need to be updated to properly work with PS7.

For context, this is where we disable SSL in the test runner: https://github.com/microsoft/navcontainerhelper/blob/main/AppHandling/PsTestFunctions.ps1#L1355
The quick version is that in PS5 and .Net Framework `System.Net.ServicePointManager.ServerCertificateValidationCallback` is global and can be set once like in the helper function linked above.
In PS7 and .Net Core, this is deprecated. Instead each `HttpClient` has it's own `HttpClientHandler` where you can disable SSL. The test runner is currently assuming the global setup.
