### PR TITLE
fix: address sql assembly conflict when creating clean database

### DIFF
--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -2308,14 +2308,28 @@ if (-not `$restartingInstance) {
                     Set-NavserverInstance -ServerInstance $serverInstance -stop
                     Copy-NavDatabase -SourceDatabaseName $databaseName -DestinationDatabaseName "tenant"
                     Remove-NavDatabase -DatabaseName $databaseName
-                    Write-Host "Exporting Application to $DatabaseName"
                     Invoke-sqlcmd -serverinstance "$DatabaseServer\$DatabaseInstance" -Database tenant -query 'CREATE USER "NT AUTHORITY\SYSTEM" FOR LOGIN "NT AUTHORITY\SYSTEM";'
+                }
+
+                # mitigate issue with Microsoft.SqlServer.SmoExtended assembly
+                # Could not load type 'Microsoft.SqlServer.Management.Common.TransferException' (caused by legacy loaded assemblies in upper stack)
+                Remove-BcContainerSession -ContainerName $containerName
+
+                Invoke-ScriptInBCContainer -containerName $containerName -scriptblock {
+                    $customConfigFile = Join-Path (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName "CustomSettings.config"
+                    [xml]$customConfig = [System.IO.File]::ReadAllText($customConfigFile)
+                    $databaseServer = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseServer']").Value
+                    $databaseInstance = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseInstance']").Value
+                    $databaseName = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value
+
+                    Write-Host "Exporting Application to $DatabaseName"
                     Export-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -DestinationDatabaseName $databaseName -Force -ServiceAccount 'NT AUTHORITY\SYSTEM' | Out-Null
                     Write-Host "Removing Application from tenant"
                     Remove-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -Force | Out-Null
                     Set-NAVServerConfiguration -ServerInstance $ServerInstance -KeyName "Multitenant" -KeyValue "true" -ApplyTo ConfigFile
                     Set-NavserverInstance -ServerInstance $serverInstance -start
                 }
+
                 $allowAppDatabaseWrite = ($additionalparameters | Where-Object { $_ -like "*defaultTenantHasAllowAppDatabaseWrite=Y" }) -ne $null
                 New-BcContainerTenant -containerName $containerName -tenantId default -allowAppDatabaseWrite:$allowAppDatabaseWrite
             }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,7 @@ When two projects reference the same folder during build (e.g. one for build and
 Increase performance when using compilerfolders on Windows
 Issue 4112 In a multi-project repository, using CompilerFolders and online environments or custom images, installOnlyReferencedApps is ignored
 Disable PSSessions for BC v28+ containers by default due to known PS7 remote session issue. Uses docker exec instead. Set usePsSessionForBc28 to true to re-enable. See https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/upgrade/known-issues
+Create new PSSession after executing Invoke-SqlCmd cmdlet to prevent assemblies conflict with Business Central cmdlets while creating new container using either useCleanDatabase or useNewDatabase switch on New-BcContainer (#4051)
 
 6.1.11
 Temporarily avoid using dotnet 10 for assemblyProbingPaths


### PR DESCRIPTION
### ❔What, Why & How

This is a workaround for issue #4051
It appears there is an assemblies conflict caused by usage of `Invoke-SqlCmd` for SMO which prevent container with clean database to be properly created.

```ps
$parameters = @{
    containerName = "myContainer"
    licenseFile = "$($pwd)\BC270.bclicense"
    copyTables = @("Add-in", "Report Layout", "Style Sheet")
    Credential = (Get-Credential)
    shortcuts = "None"
    auth = "NavUserPassword"
    artifactUrl = (Get-BcArtifactUrl -type Sandbox -Country fr -version 27)
    useCleanDatabase = $true
    multitenant = $true
    EnableTaskScheduler = $false
    accept_eula = $true
    AdditionalParameters = @("-e defaultTenantHasAllowAppDatabaseWrite=Y")
    isolation = "process"
    useNewDatabase = $true
}

New-BcContainer @parameters
```

**Symptom**
When executing `Export-NAVApplication` Business Central cmdlet, the following exception happens:

```
Could not load type 'Microsoft.SqlServer.Management.Common.TransferException' (caused by legacy loaded assemblies in upper stack)
```

**Diagnose**

However, when commenting the following section, the container creation is completing successfully : https://github.com/microsoft/navcontainerhelper/blob/2171cde699df6f867438792e6e8875acc6fca329/ContainerHandling/New-NavContainer.ps1#L2313-L2320

Running the following commands afterwhile does not throw the exception :

```ps
Invoke-ScriptInBCContainer -containerName $containerName -scriptblock {
    $customConfigFile = Join-Path (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName "CustomSettings.config"
    [xml]$customConfig = [System.IO.File]::ReadAllText($customConfigFile)
    $databaseServer = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseServer']").Value
    $databaseInstance = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseInstance']").Value
    $databaseName = $customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value

    Write-Host "Exporting NAV Application..."
    Export-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -DestinationDatabaseName $databaseName -Force -ServiceAccount 'NT AUTHORITY\SYSTEM' | Out-Null
    Write-Host "Removing Application from tenant"
    Remove-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -Force | Out-Null
}
```

The exact same behavior occures when upper commands are executed afterwhile using `docker exec -it {containerName} powershell`

**Resulting Hotfix**

Invoke `Remove-BcContainerSession` is ensuring used session is clean of any previously loaded assemblies - which prevent the exception to happen.

Related to issue: #4051

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [x] Update ReleaseNotes.txt
- [ ] Add telemetry