### PR TITLE
Fix .Count error by wrapping pipeline results in @()

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -1471,7 +1471,7 @@ $sortedAppFolders | ForEach-Object { Write-Host "- $_" }
 Write-Host "External dependencies"
 if ($unknownAppDependencies) {
     $unknownAppDependencies | ForEach-Object { Write-Host "- $_" }
-    $missingAppDependencies = $unknownAppDependencies | ForEach-Object { $_.Split(':')[0] }
+    $missingAppDependencies = @($unknownAppDependencies | ForEach-Object { $_.Split(':')[0] })
 }
 else {
     Write-Host "- None"
@@ -1487,7 +1487,7 @@ else {
     Write-Host "External TestApp dependencies"
     if ($unknownTestAppDependencies) {
         $unknownTestAppDependencies | ForEach-Object { Write-Host "- $_" }
-        $missingTestAppDependencies = $unknownTestAppDependencies | ForEach-Object { $_.Split(':')[0] }
+        $missingTestAppDependencies = @($unknownTestAppDependencies | ForEach-Object { $_.Split(':')[0] })
     }
     else {
         Write-Host "- None"


### PR DESCRIPTION
## Problem

After commit 4c189e1d, calling \.Count\ on \\\ and \\\ fails when there is exactly one external dependency:

\\\
The property 'Count' cannot be found on this object. Verify that the property exists.
\\\

## Root Cause

On lines 1474 and 1490, the pipeline results were not wrapped in \@()\. When \ForEach-Object\ returns a single result, PowerShell returns a scalar string instead of an array. Scalars don't support \.Count\ in all contexts.

## Fix

Wrap both pipeline assignments in \@()\ to ensure they are always arrays, consistent with the else branches that already use \@()\.