### PR TITLE
Add RunTests for versions 27 and 28

### DIFF
--- a/Tests/GetAndRunTests (version 27).Tests.ps1
+++ b/Tests/GetAndRunTests (version 27).Tests.ps1
@@ -1,0 +1,50 @@
+Param(
+    [string] $licenseFile,
+    [string] $buildlicenseFile
+)
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelperFunctions.ps1')
+    $appPublisher = "Cronus Denmark A/S"
+    $appName = "Hello ÆØÅ"
+    $appVersion = "1.0.0.0"
+    $bcAppId = "cb99d78b-f9db-4a1e-822a-0c9c444535df"
+    $runTestsInVersion  = 27
+    $bcContainerName = "bcserver"
+}
+
+AfterAll {
+    . (Join-Path $PSScriptRoot '_RemoveBcContainer.ps1')
+}
+
+Describe 'AppHandling' {
+
+    It 'Get/RunTests' {
+        $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
+        New-BcContainer -accept_eula `
+                        -accept_outdated `
+                        -containerName $bcContainerName `
+                        -artifactUrl $artifactUrl `
+                        -auth NavUserPassword `
+                        -Credential $credential `
+                        -updateHosts `
+                        -includeTestToolkit
+        
+        $tests = (Get-TestsFromBCContainer -containerName $bcContainerName -credential $credential -extensionId "fa3e2564-a39e-417f-9be6-c0dbe3d94069") | Where-Object { $_.id -eq 134006 -or $_.id -eq 134007 }
+        $tests.Count | Should -be 2
+
+        $first = $true
+        $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$bcContainerName\result.xml"
+        $tests | ForEach-Object {
+            Run-TestsInBcContainer -containerName $bcContainerName `
+                                   -credential $credential `
+                                   -XUnitResultFileName $resultsFile `
+                                   -AppendToXUnitResultFile:(!$first) `
+                                   -detailed `
+                                   -testCodeunit $_.Id `
+                                   -returnTrueIfAllPassed | Out-Null
+            $first = $false
+        }
+        $resultsFile | Should -Exist
+    }
+}

--- a/Tests/GetAndRunTests (version 28).Tests.ps1
+++ b/Tests/GetAndRunTests (version 28).Tests.ps1
@@ -1,0 +1,50 @@
+Param(
+    [string] $licenseFile,
+    [string] $buildlicenseFile
+)
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '_TestHelperFunctions.ps1')
+    $appPublisher = "Cronus Denmark A/S"
+    $appName = "Hello ÆØÅ"
+    $appVersion = "1.0.0.0"
+    $bcAppId = "cb99d78b-f9db-4a1e-822a-0c9c444535df"
+    $runTestsInVersion  = 28
+    $bcContainerName = "bcserver"
+}
+
+AfterAll {
+    . (Join-Path $PSScriptRoot '_RemoveBcContainer.ps1')
+}
+
+Describe 'AppHandling' {
+
+    It 'Get/RunTests' {
+        $artifactUrl = Get-BCArtifactUrl -type OnPrem -version "$runTestsInVersion" -country "w1" -select Latest
+        New-BcContainer -accept_eula `
+                        -accept_outdated `
+                        -containerName $bcContainerName `
+                        -artifactUrl $artifactUrl `
+                        -auth NavUserPassword `
+                        -Credential $credential `
+                        -updateHosts `
+                        -includeTestToolkit
+        
+        $tests = (Get-TestsFromBCContainer -containerName $bcContainerName -credential $credential -extensionId "fa3e2564-a39e-417f-9be6-c0dbe3d94069") | Where-Object { $_.id -eq 134006 -or $_.id -eq 134007 }
+        $tests.Count | Should -be 2
+
+        $first = $true
+        $resultsFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$bcContainerName\result.xml"
+        $tests | ForEach-Object {
+            Run-TestsInBcContainer -containerName $bcContainerName `
+                                   -credential $credential `
+                                   -XUnitResultFileName $resultsFile `
+                                   -AppendToXUnitResultFile:(!$first) `
+                                   -detailed `
+                                   -testCodeunit $_.Id `
+                                   -returnTrueIfAllPassed | Out-Null
+            $first = $false
+        }
+        $resultsFile | Should -Exist
+    }
+}


### PR DESCRIPTION
### ❔What, Why & How

The RunTests pipeline currently covers versions up to and including 26. This adds test coverage for versions 27 and 28 by creating two new test files following the same pattern as the existing version-specific tests.

The pipeline's `AnalyzeTests` job dynamically discovers test files via `Get-ChildItem`, so no workflow changes are needed -- the new files are picked up automatically.

Related to issue: #

### ✅ Checklist

- [x] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry