### PR TITLE
ContainerHelper: guard against null Config.Env in Flush-ContainerHelperCache

### DIFF
--- a/ContainerHandling/Flush-ContainerHelperCache.ps1
+++ b/ContainerHandling/Flush-ContainerHelperCache.ps1
@@ -199,7 +199,10 @@ try {
                 if ($usedImages -notcontains $imageName) {
                     $imageID = $_.Split('|')[1]
                     $inspect = docker inspect $imageID | ConvertFrom-Json
-                    $artifactUrl = $inspect.config.Env | Where-Object { $_ -like "artifactUrl=*" }
+                    $artifactUrl = $null
+                    if ($null -ne $inspect.config -and $inspect.config.PSObject.Properties['Env']) {
+                        $artifactUrl = $inspect.config.Env | Where-Object { $_ -like "artifactUrl=*" }
+                    }
                     if ($artifactUrl) {
                         $artifactUrl = $artifactUrl.Split('?')[0]
                         "artifactUrl=https://bcartifacts*.net/",


### PR DESCRIPTION
## Summary

Fixes #4073

Flush-ContainerHelperCache crashes with PropertyNotFoundException when iterating over Docker images that include non-BC images (e.g. mcr.microsoft.com/windows/nanoserver:ltsc2022, 	obiasfenster/traefik-for-windows). The module sets Set-StrictMode -Version 2.0 globally, which throws instead of returning \ when a missing property is accessed on a ConvertFrom-Json result.

## Root Cause

Line 202 (original):
`powershell
\ = \.config.Env | Where-Object { \ -like "artifactUrl=*" }
`

Two failure modes:
- \.config is \ for images that have no Config section
- \.config exists but has no Env property (e.g. minimal or non-standard Windows images)

Both cases throw PropertyNotFoundException in strict mode, terminating the ForEach-Object block.

## Fix

Add a two-part guard before the access:
1. \ -ne \.config - handles null Config
2. \.config.PSObject.Properties['Env'] - probes for the Env property without throwing in strict mode (returns \ rather than throwing when the property is absent)

Non-BC images without an rtifactUrl env var are safely skipped. BC images are unaffected. The lseif (\) path immediately following already uses 	ry {} catch {} for the same reason (Config.Labels access on unknown images), confirming this is an established pattern for handling inspect variability.

## How to Test

1. Pull a non-BC Windows image that has null or no Config.Env:
   `powershell
   docker pull mcr.microsoft.com/windows/nanoserver:ltsc2022
   `
2. Run Flush-ContainerHelperCache -keepDays 15
3. Before fix: PropertyNotFoundException thrown, flush aborts
4. After fix: command completes, non-BC image is skipped cleanly