### PR TITLE
Disable warning in Disable-SslVerification 

### DIFF
--- a/AppHandling/PsTestFunctions.ps1
+++ b/AppHandling/PsTestFunctions.ps1
@@ -1371,6 +1371,7 @@ function Disable-SslVerification
     if (-not ([System.Management.Automation.PSTypeName]"SslVerification").Type)
     {
 $sslCallbackCode = @"
+    #pragma warning disable SYSLIB0014
     using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
 
@@ -1380,6 +1381,7 @@ $sslCallbackCode = @"
         public static void Disable() { System.Net.ServicePointManager.ServerCertificateValidationCallback = DisabledServerCertificateValidationCallback; }
         public static void Enable()  { System.Net.ServicePointManager.ServerCertificateValidationCallback = null; }
     }
+    #pragma warning restore SYSLIB0014
 "@
         Add-Type -TypeDefinition $sslCallbackCode
     }


### PR DESCRIPTION
Add #pragma warning disable SYSLIB0014 to suppress the obsolete error for ServicePointManager in Add-Type compiled C# code. The API is obsolete but still functional at runtime for HttpWebRequest-based connections.

### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->
Disable warning in Disable-SslVerification to allow for .NET 10 update

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
