### PR TITLE
Use manifest.json dotNetVersion for .NET assembly probing paths

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -154,9 +154,21 @@ try {
     }
 
     $containerFolder = Get-BcContainerPath -containerName $containerName -path (Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$containerName")
+    # Read the required .NET version from the manifest (stored during New-BcContainer)
+    $requiredDotNetMajor = 0
+    $manifestFile = Join-Path $bcContainerHelperConfig.hostHelperFolder "Extensions\$containerName\manifest.json"
+    if (Test-Path $manifestFile) {
+        try {
+            $manifest = Get-Content $manifestFile -Encoding UTF8 | ConvertFrom-Json
+            if ($manifest.dotNetVersion) {
+                $requiredDotNetMajor = ([System.Version]$manifest.dotNetVersion).Major
+            }
+        }
+        catch {}
+    }
     if (!$PSBoundParameters.ContainsKey("assemblyProbingPaths")) {
         if ($platformversion.Major -ge 13) {
-            $assemblyProbingPaths = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($containerFolder, $appProjectFolder, $platformVersion)
+            $assemblyProbingPaths = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($containerFolder, $appProjectFolder, $platformVersion, $requiredDotNetMajor)
                 $assemblyProbingPaths = ""
                 $netpackagesPath = Join-Path $appProjectFolder ".netpackages"
                 if (Test-Path $netpackagesPath) {
@@ -188,7 +200,24 @@ try {
                     }
 
                     $assemblyProbingPaths += """$dotnetAssembliesFolder"""
-                    $assemblyProbingPaths = """C:\Program Files\dotnet\shared"",$assemblyProbingPaths"
+                    # Use specific .NET version paths if the required version is known from the artifact manifest
+                    $dotNetSharedPath = ""
+                    if ($requiredDotNetMajor -gt 0) {
+                        $dotNetCorePath = 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App'
+                        if (Test-Path $dotNetCorePath) {
+                            $matchingVersion = Get-ChildItem $dotNetCorePath | ForEach-Object {
+                                try { [System.Version]$_.Name } catch {}
+                            } | Where-Object { $_.Major -eq $requiredDotNetMajor } | Sort-Object -Descending | Select-Object -First 1
+                            if ($matchingVersion) {
+                                Write-Host "Using .NET $matchingVersion for assembly probing (artifact requires .NET $requiredDotNetMajor)"
+                                $dotNetSharedPath = """C:\Program Files\dotnet\shared\Microsoft.NETCore.App\$matchingVersion"",""C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$matchingVersion"""
+                            }
+                        }
+                    }
+                    if (-not $dotNetSharedPath) {
+                        $dotNetSharedPath = """C:\Program Files\dotnet\shared"""
+                    }
+                    $assemblyProbingPaths = "$dotNetSharedPath,$assemblyProbingPaths"
                 }
                 else {
                     $assemblyProbingPaths += """$serviceTierFolder"",""C:\Program Files (x86)\Open XML SDK\V2.5\lib"""
@@ -199,7 +228,7 @@ try {
                     }
                 }
                 $assemblyProbingPaths
-            } -ArgumentList $containerFolder, $containerProjectFolder, $platformversion
+            } -ArgumentList $containerFolder, $containerProjectFolder, $platformversion, $requiredDotNetMajor
         }
     }
 

--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -314,8 +314,33 @@ function Compile-AppWithBcCompilerFolder {
             $probingPaths = @((Join-Path $dllsPath "OpenXML")) + $probingPaths
         }
         elseif ($platformversion.Major -ge 22) {
-            if ($dotNetRuntimeVersionInstalled -ge [System.Version]$bcContainerHelperConfig.MinimumDotNetRuntimeVersionStr) {
-                $probingPaths = @((Join-Path $dllsPath "OpenXML"), "C:\Program Files\dotnet\shared\Microsoft.NETCore.App\$dotNetRuntimeVersionInstalled", "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$dotNetRuntimeVersionInstalled") + $probingPaths
+            # Determine the correct .NET runtime version for assembly probing paths
+            # If the artifact ships a manifest.json with a dotNetVersion, use the matching installed runtime
+            $dotNetVersionForProbing = $dotNetRuntimeVersionInstalled
+            $manifestFile = Join-Path $compilerFolder "manifest.json"
+            if (Test-Path $manifestFile) {
+                try {
+                    $manifest = Get-Content $manifestFile -Encoding UTF8 | ConvertFrom-Json
+                    if ($manifest.dotNetVersion) {
+                        $requiredDotNetMajor = ([System.Version]$manifest.dotNetVersion).Major
+                        $dotNetCorePath = 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App'
+                        if (Test-Path $dotNetCorePath) {
+                            $matchingVersion = Get-ChildItem $dotNetCorePath | ForEach-Object {
+                                try { [System.Version]$_.Name } catch {}
+                            } | Where-Object { $_.Major -eq $requiredDotNetMajor } | Sort-Object -Descending | Select-Object -First 1
+                            if ($matchingVersion -and (Test-Path "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$matchingVersion")) {
+                                Write-Host "Using .NET $matchingVersion for assembly probing (artifact requires .NET $requiredDotNetMajor)"
+                                $dotNetVersionForProbing = $matchingVersion
+                            }
+                        }
+                    }
+                }
+                catch {
+                    Write-Host "Warning: Could not read manifest.json from compiler folder: $($_.Exception.Message)"
+                }
+            }
+            if ($dotNetVersionForProbing -ge [System.Version]$bcContainerHelperConfig.MinimumDotNetRuntimeVersionStr) {
+                $probingPaths = @((Join-Path $dllsPath "OpenXML"), "C:\Program Files\dotnet\shared\Microsoft.NETCore.App\$dotNetVersionForProbing", "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$dotNetVersionForProbing") + $probingPaths
             }
             else {
                 $probingPaths = @((Join-Path $dllsPath "OpenXML")) + $probingPaths

--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -175,6 +175,12 @@ try {
                 Get-ChildItem -Path $platformAppsPath -Filter '*.app' -Recurse | ForEach-Object { Copy-Item -Path $_.FullName -Destination $symbolsPath }
             }
         }
+        # Copy manifest.json for .NET version resolution during compilation
+        $manifestSource = Join-Path $appArtifactPath "manifest.json"
+        if (Test-Path $manifestSource) {
+            $manifestDest = if ($cacheFolder) { $cacheFolder } else { $compilerFolder }
+            Copy-Item -Path $manifestSource -Destination (Join-Path $manifestDest "manifest.json") -Force
+        }
     }
 
     $dotNetSharedFolder = Join-Path $dllsPath 'shared'
@@ -241,6 +247,11 @@ try {
         if (!$vsixFile) {
             Write-Host "Copying compiler from cache"
             Copy-Item -Path $compilerPath -Destination $compilerFolder -Recurse -Force
+        }
+        # Copy manifest.json from cache to compiler folder
+        $cachedManifest = Join-Path $cacheFolder "manifest.json"
+        if (Test-Path $cachedManifest) {
+            Copy-Item -Path $cachedManifest -Destination (Join-Path $compilerFolder "manifest.json") -Force
         }
     }
 

--- a/ContainerHandling/New-NavContainer.ps1
+++ b/ContainerHandling/New-NavContainer.ps1
@@ -926,6 +926,12 @@ try {
             $parameters += @("--env isBcSandbox=N")
         }
 
+        # Copy manifest.json for use during compilation (.NET version resolution, etc.)
+        $manifestSource = Join-Path $appArtifactPath "manifest.json"
+        if (Test-Path $manifestSource) {
+            Copy-Item -Path $manifestSource -Destination (Join-Path $containerFolder "manifest.json") -Force
+        }
+
         $dvdVersion = $appmanifest.Version
         $dvdCountry = $appManifest.Country
         $dvdPlatform = $appManifest.Platform


### PR DESCRIPTION
### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->

When the platform changes .NET version or when GitHub rolls out newer .NET version on the image we've seen examples of compilation issues because BCContainerHelper picks the wrong .NET version for assembly probing paths. 

We already have a manifest.json file in the artifact that includes the .NET version. This PRs adds handling to actually use it so we pick up the .NET major version that the manifest.json dictates. 

Test run (BCContainerHelper): https://github.com/microsoft/navcontainerhelper/actions/runs/24881416361/job/72850576614
Test run (BCApps w. .NET 10 artifact): https://github.com/microsoft/BCApps/actions/runs/24881656168

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
