### PR TITLE
[Draft] Add Get-DotNetMajorVersionForPlatform helper for .NET version fallback

### DIFF
--- a/AppHandling/Compile-AppInNavContainer.ps1
+++ b/AppHandling/Compile-AppInNavContainer.ps1
@@ -166,6 +166,9 @@ try {
         }
         catch {}
     }
+    if ($requiredDotNetMajor -eq 0) {
+        $requiredDotNetMajor = Get-DotNetMajorVersionForPlatform -platformVersion $platformversion
+    }
     if (!$PSBoundParameters.ContainsKey("assemblyProbingPaths")) {
         if ($platformversion.Major -ge 13) {
             $assemblyProbingPaths = Invoke-ScriptInBcContainer -containerName $containerName -ScriptBlock { Param($containerFolder, $appProjectFolder, $platformVersion, $requiredDotNetMajor)

--- a/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
+++ b/CompilerFolderHandling/Compile-AppWithBcCompilerFolder.ps1
@@ -316,27 +316,34 @@ function Compile-AppWithBcCompilerFolder {
         elseif ($platformversion.Major -ge 22) {
             # Determine the correct .NET runtime version for assembly probing paths
             # If the artifact ships a manifest.json with a dotNetVersion, use the matching installed runtime
+            # For older artifacts without dotNetVersion, fall back to version-based lookup
             $dotNetVersionForProbing = $dotNetRuntimeVersionInstalled
+            $requiredDotNetMajor = 0
             $manifestFile = Join-Path $compilerFolder "manifest.json"
             if (Test-Path $manifestFile) {
                 try {
                     $manifest = Get-Content $manifestFile -Encoding UTF8 | ConvertFrom-Json
                     if ($manifest.dotNetVersion) {
                         $requiredDotNetMajor = ([System.Version]$manifest.dotNetVersion).Major
-                        $dotNetCorePath = 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App'
-                        if (Test-Path $dotNetCorePath) {
-                            $matchingVersion = Get-ChildItem $dotNetCorePath | ForEach-Object {
-                                try { [System.Version]$_.Name } catch {}
-                            } | Where-Object { $_.Major -eq $requiredDotNetMajor } | Sort-Object -Descending | Select-Object -First 1
-                            if ($matchingVersion -and (Test-Path "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$matchingVersion")) {
-                                Write-Host "Using .NET $matchingVersion for assembly probing (artifact requires .NET $requiredDotNetMajor)"
-                                $dotNetVersionForProbing = $matchingVersion
-                            }
-                        }
                     }
                 }
                 catch {
                     Write-Host "Warning: Could not read manifest.json from compiler folder: $($_.Exception.Message)"
+                }
+            }
+            if ($requiredDotNetMajor -eq 0) {
+                $requiredDotNetMajor = Get-DotNetMajorVersionForPlatform -platformVersion $platformversion
+            }
+            if ($requiredDotNetMajor -gt 0) {
+                $dotNetCorePath = 'C:\Program Files\dotnet\shared\Microsoft.NETCore.App'
+                if (Test-Path $dotNetCorePath) {
+                    $matchingVersion = Get-ChildItem $dotNetCorePath | ForEach-Object {
+                        try { [System.Version]$_.Name } catch {}
+                    } | Where-Object { $_.Major -eq $requiredDotNetMajor } | Sort-Object -Descending | Select-Object -First 1
+                    if ($matchingVersion -and (Test-Path "C:\Program Files\dotnet\shared\Microsoft.AspNetCore.App\$matchingVersion")) {
+                        Write-Host "Using .NET $matchingVersion for assembly probing (artifact requires .NET $requiredDotNetMajor)"
+                        $dotNetVersionForProbing = $matchingVersion
+                    }
                 }
             }
             if ($dotNetVersionForProbing -ge [System.Version]$bcContainerHelperConfig.MinimumDotNetRuntimeVersionStr) {

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -1001,6 +1001,26 @@ function testPfxCertificate([string] $pfxFile, [SecureString] $pfxPassword, [str
     }
 }
 
+function Get-DotNetMajorVersionForPlatform {
+    Param(
+        [Parameter(Mandatory=$true)]
+        [System.Version]$platformVersion
+    )
+    if ($platformVersion.Major -lt 23) {
+        return 0
+    }
+    # Platform 23.x used .NET 6
+    if ($platformVersion.Major -lt 24) {
+        return 6
+    }
+    # Platform 24.x - 28.x uses .NET 8
+    if ($platformVersion.Major -lt 29) {
+        return 8
+    }
+    # Platform 29.x+ uses .NET 10
+    return 10
+}
+
 function GetHash {
     param(
         [string] $str


### PR DESCRIPTION
### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->

Add a central helper function that maps BC platform version to .NET major version, used as a fallback when manifest.json lacks the dotNetVersion property (only present in newer artifacts).

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
