### PR TITLE
Fix BCPT test job failures not surfaced and empty results not reported

### DIFF
--- a/AppHandling/Run-BCPTTestsInBcContainer.ps1
+++ b/AppHandling/Run-BCPTTestsInBcContainer.ps1
@@ -188,8 +188,9 @@ try {
         } -ArgumentList (Join-Path $bcContainerHelperConfig.hostHelperFolder "extensions\$containerName\my\TestRunner"), $params, $suiteCode, $serviceUrl, $testPage | Wait-Job
 
         if ($job.State -ne "Completed") {
-            Write-Host "Running performance test failed"
-            $job | Receive-Job
+            $jobOutput = $job | Receive-Job | Out-String
+            $job | Remove-Job | Out-Null
+            throw "Running BCPT performance test failed. Job state: $($job.State). Output: $jobOutput"
         }
         $job | Remove-Job | Out-Null
     }
@@ -255,6 +256,9 @@ try {
             -Method 'GET' `
             -Query 'bcptLogEntries'
         
+        if (-not $response.value -or @($response.value).Count -eq 0) {
+            Write-Host "::warning::BCPT tests produced no log entries. The test suite may have failed to start or the test codeunits exited without recording any measurements. Check the suite configuration and verify the test codeunit IDs match those in the BCPT suite definition."
+        }
         $response.value
     }
 }


### PR DESCRIPTION
## Problem

When running BCPT performance tests via the \connectFromHost = \True\ code path, \Run-BCPTTestsInBcContainer.ps1\ launches a background job to run \RunBCPTTests.ps1\ from the host. If that job fails (state is not \Completed\), the current code only prints a message and continues, fetching what is effectively an empty \cptLogEntries\ response from the Business Central API.

The empty result is then saved to the results file. When \AnalyzeTests\ in AL-Go reads the file, it finds no entries, writes nothing to the GitHub step summary, and the build succeeds without any indication that the performance tests did not produce output.

See: microsoft/AL-Go#2158

## Changes

### Run-BCPTTestsInBcContainer.ps1

- When the background test job does not complete successfully, collect the job output and throw an error. This surfaces the failure immediately rather than silently continuing with an empty result set.
- After fetching \cptLogEntries\, check whether the response contains any entries. If it does not, emit a GitHub Actions warning annotation so the empty result is visible in the build log even when the job exits without error.

## Testing

1. Set up a Business Central container with a BCPT test app.
2. Configure a \cptSuiteCode\ that references a codeunit that does not exist in the container.
3. Run \Run-BCPTTestsInBcContainer\ with the broken suite.
4. Before this fix: the build succeeds with no output.
5. After this fix: a warning annotation appears in the build log stating that no BCPT log entries were found.

For the job failure case:
1. Simulate a job failure by passing invalid parameters that cause the job to fault.
2. Before this fix: a message is printed and execution continues.
3. After this fix: an error is thrown and the build fails with the job output included.