### PR TITLE
New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform

### DIFF
--- a/CompilerFolderHandling/New-BcCompilerFolder.ps1
+++ b/CompilerFolderHandling/New-BcCompilerFolder.ps1
@@ -6,6 +6,8 @@
   Returns a compilerFolder path, which can be used for functions like Compile-AppWithBcCompilerFolder or Remove-BcCompilerFolder
  .PARAMETER artifactUrl
   Artifacts URL to download the compiler and all .app files from
+ .PARAMETER platformArtifactUrl
+  Url for platform artifact to use. Use this when you want to use a different platform than the one related to artifactUrl.
  .PARAMETER containerName
   Name of the folder in which to create the compiler folder or empty to use a default name consisting of type-version-country
  .PARAMETER cacheFolder
@@ -34,6 +36,7 @@
 function New-BcCompilerFolder {
     Param(
         [string] $artifactUrl,
+        [string] $platformArtifactUrl = '',
         [string] $containerName = '',
         [string] $cacheFolder = '',
         [string] $packagesFolder = '',
@@ -43,6 +46,9 @@ function New-BcCompilerFolder {
 
 $telemetryScope = InitTelemetryScope -name $MyInvocation.InvocationName -parameterValues $PSBoundParameters -includeParameters @()
 try {
+    if ($platformArtifactUrl -and -not $artifactUrl) {
+        throw "You have to specify artifactUrl when using platformArtifactUrl."
+    }
     $parts = $artifactUrl.Split('?')[0].Split('/')
     if ($parts.Count -lt 6) {
         throw "Invalid artifact URL"
@@ -56,7 +62,7 @@ try {
     if ($version -lt "16.0.0.0") {
         throw "Containerless compiling is not supported with versions before 16.0"
     }
-    
+
     if (!$containerName) {
         $containerName = [GUID]::NewGuid().ToString()
     }
@@ -81,7 +87,7 @@ try {
 
     $newtonSoftDllPath = ''
     if ($includeAL -or !(Test-Path $symbolsPath)) {
-        $artifactPaths = Download-Artifacts -artifactUrl $artifactUrl -includePlatform
+        $artifactPaths = Download-Artifacts -artifactUrl $artifactUrl -platformArtifactUrl $platformArtifactUrl -includePlatform
         $appArtifactPath = $artifactPaths[0]
         $platformArtifactPath = $artifactPaths[1]
         $newtonSoftDllPath = Join-Path $platformArtifactPath "ServiceTier\*\Microsoft Dynamics NAV\*\Service\Newtonsoft.Json.dll" -Resolve
@@ -144,7 +150,7 @@ try {
             Copy-Item -Path (Join-Path $extensionsFolder '*.app') -Destination $symbolsPath
             $platformAppsPath = Join-Path $platformArtifactPath '?pplications' -Resolve
             $appAppsPath = Join-Path $AppArtifactPath '?pplications.*' -Resolve
-            
+
             $platformApps = @(Get-ChildItem -Path $platformAppsPath -Filter '*.app' -Recurse)
             Write-Host "PlatForm apps"
             $platformApps | ForEach-Object { Write-Host "- $($_.Name)" }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 6.1.15
+New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform than the one related to artifactUrl (like New-BcContainer)
 Add retry with exponential backoff in DockerDo for transient MCR pull failures caused by Azure Front Door CDN/WAF blocks
 
 6.1.14


### PR DESCRIPTION
Similar to `New-BcContainer`, this adds a `platformArtifactUrl` parameter to `New-BcCompilerFolder` that allows using a different platform artifact than the one associated with the `artifactUrl`.

## Changes

- Added `platformArtifactUrl` parameter to `New-BcCompilerFolder`
- Added validation that `artifactUrl` must be specified when using `platformArtifactUrl`
- Pass `platformArtifactUrl` through to `Download-Artifacts`
- Added release notes entry