### PR TITLE
Tune DockerDo CDN/WAF retry backoff to 5/15/30/60/120s

### DIFF
--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -178,14 +178,15 @@ function DockerDo {
     # Retry logic for docker pull to handle transient CDN/WAF errors.
     # Azure Front Door occasionally blocks MCR requests, returning an HTML error page
     # ("The request is blocked") instead of a proper registry response. This causes docker
-    # to report "pull access denied" even though the image exists. Retrying with exponential
-    # backoff (2s, 4s, 8s, 16s, 32s) resolves these intermittent failures.
+    # to report "pull access denied" even though the image exists. Observed WAF block
+    # windows can last well over a minute, so the backoff schedule (5s, 30s, 60s, 120s,
+    # 180s; total ~6.6 min) is deliberately patient rather than aggressive early.
+    $retryDelays = @(5, 30, 60, 120, 180)
     $maxRetries = 0
     if ($command -eq "pull") {
-        $maxRetries = 5
+        $maxRetries = $retryDelays.Count
     }
     $attempt = 0
-    $waitTime = 2
 
     while ($true) {
         $attempt++
@@ -250,11 +251,11 @@ function DockerDo {
             # Only retry for pull commands when the HTML WAF/CDN block signature is present;
             # genuine auth failures and missing-image errors do not contain HTML and fail immediately.
             if ($attempt -le $maxRetries -and $err -match 'pull access denied' -and ($err -match '<html' -or $err -match 'The request is blocked')) {
+                $waitTime = $retryDelays[$attempt - 1]
                 if (!$silent) {
                     Write-Host "Docker pull failed due to a CDN/WAF block (attempt $attempt of $($maxRetries + 1)), retrying in $waitTime seconds..."
                 }
                 Start-Sleep -Seconds $waitTime
-                $waitTime = $waitTime * 2
                 continue
             }
 

--- a/HelperFunctions.ps1
+++ b/HelperFunctions.ps1
@@ -179,9 +179,9 @@ function DockerDo {
     # Azure Front Door occasionally blocks MCR requests, returning an HTML error page
     # ("The request is blocked") instead of a proper registry response. This causes docker
     # to report "pull access denied" even though the image exists. Observed WAF block
-    # windows can last well over a minute, so the backoff schedule (5s, 30s, 60s, 120s,
-    # 180s; total ~6.6 min) is deliberately patient rather than aggressive early.
-    $retryDelays = @(5, 30, 60, 120, 180)
+    # windows can last well over a minute, so the backoff schedule (5s, 15s, 30s, 60s,
+    # 120s; total ~3.8 min) is deliberately patient rather than aggressive early.
+    $retryDelays = @(5, 15, 30, 60, 120)
     $maxRetries = 0
     if ($command -eq "pull") {
         $maxRetries = $retryDelays.Count

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 6.1.15
 New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform than the one related to artifactUrl (like New-BcContainer)
-Add retry with exponential backoff in DockerDo for transient MCR pull failures caused by Azure Front Door CDN/WAF blocks (delays: 5s, 30s, 60s, 120s, 180s)
+Add retry with exponential backoff in DockerDo for transient MCR pull failures caused by Azure Front Door CDN/WAF blocks (delays: 5s, 15s, 30s, 60s, 120s)
 Add support for framework-dependent AL Language VSIX (flat bin/ layout without platform-specific subdirectories)
 
 6.1.14

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 6.1.15
 New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform than the one related to artifactUrl (like New-BcContainer)
-Add retry with exponential backoff in DockerDo for transient MCR pull failures caused by Azure Front Door CDN/WAF blocks
+Add retry with exponential backoff in DockerDo for transient MCR pull failures caused by Azure Front Door CDN/WAF blocks (delays: 5s, 30s, 60s, 120s, 180s)
 Add support for framework-dependent AL Language VSIX (flat bin/ layout without platform-specific subdirectories)
 
 6.1.14


### PR DESCRIPTION
## Why

The retry loop in `DockerDo` (added in 6.1.14 to handle transient Azure Front Door WAF blocks on MCR) is correctly triggering, but the original `2/4/8/16/32s` schedule only covers ~62s total. Observed WAF block windows in CI runs (e.g. BCApps, 19 occurrences in the last 7 days) routinely last longer than that, so all 6 attempts get exhausted and the pull still fails.

## What

Keep the trigger condition and retry count unchanged. Only the delay schedule changes: replace the doubling `$waitTime` with an explicit `@(5, 15, 30, 60, 120)` array indexed by attempt.

- Short first retry (5s) to catch brief hiccups cheaply
- Then 15s, 30s, 60s, 120s
- Total budget ~3.8 min (230s) instead of ~1 min
- Log message format and the `pull access denied` + HTML/`The request is blocked` detection are untouched

Also updates the corresponding `ReleaseNotes.txt` line for 6.1.15 (the original entry hasn't shipped yet) to reflect the new schedule.