### PR TITLE
Fix AS0054 when AppSourceCop runs on test apps

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -2348,7 +2348,7 @@ Write-Host -ForegroundColor Yellow @'
         }
     }
 
-    if ($enableAppSourceCop -and $app) {
+    if ($enableAppSourceCop -and ($app -or $enableCodeAnalyzersOnTestApps)) {
         $appSourceCopJson = @{}
         $saveit = $false
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 6.1.16
+Run-AlPipeline: Fix AS0054 by creating AppSourceCop.json (with mandatory affixes) for test/bcpt apps when enableCodeAnalyzersOnTestApps is set
 
 6.1.15
 New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform than the one related to artifactUrl (like New-BcContainer)


### PR DESCRIPTION
### ❔What, Why & How

When enableCodeAnalyzersOnTestApps is set, Run-AlPipeline enables the AppSourceCop analyzer on test/bcpt apps but only generated AppSourceCop.json for regular apps, so test apps failed with AS0054 (no mandatory affixes configured).

The AppSourceCop.json creation now uses the same condition ($app -or $enableCodeAnalyzersOnTestApps) as the analyzer enablement, so the affixes config is written wherever the analyzer actually runs.

Related to issue: #

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
