### PR TITLE
fix path comparison to casesensitive

### DIFF
--- a/AppHandling/Extract-AppFileToFolder.ps1
+++ b/AppHandling/Extract-AppFileToFolder.ps1
@@ -123,7 +123,7 @@ try {
         $zipArchive.Entries | ForEach-Object {
             $fullname = Join-Path $appFolder ([Uri]::UnescapeDataString($_.FullName))
             $dir = [System.IO.Path]::GetDirectoryName($fullname)
-            if ($dir -ne $prevdir) {
+            if ($dir -cne $prevdir) {
                 if (-not (Test-Path $dir -PathType Container)) {
                     New-Item -Path $dir -ItemType Directory | Out-Null
                 }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,6 @@
 6.1.16
 Run-AlPipeline: Fix AS0054 by creating AppSourceCop.json (with mandatory affixes) for test/bcpt apps when enableCodeAnalyzersOnTestApps is set
+Fix error when extracting apps whit paths that differ only in their casing
 
 6.1.15
 New-BcCompilerFolder: Add platformArtifactUrl parameter to allow using a different platform than the one related to artifactUrl (like New-BcContainer)


### PR DESCRIPTION
### ❔What, Why & How

This pull request makes a small update to the directory comparison logic in `Extract-AppFileToFolder.ps1` to use a case-insensitive comparison operator, improving reliability when handling file paths across different environments.

If an app contains two folders that differ only in case (e.g., Codeunit and CodeUnit), the extract operation fails on Unix systems.

Related to issue: #


### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [x] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
