### PR TITLE
Fix sorting of versions for multiple nuget packages

### DIFF
--- a/LinuxTests/NuGet.Tests.ps1
+++ b/LinuxTests/NuGet.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
 }
 
 AfterAll {
-    
+
 }
 
 Describe 'Download' {
@@ -23,5 +23,73 @@ Describe 'Download' {
 
         $files = @(Get-ChildItem $folder)
         $files.Count | Should -Be 6
+    }
+}
+
+Describe 'Find-BcNuGetPackage' {
+    BeforeEach {
+        # Configure the app source feed and continia feed for different package ids to test sorting accross multiple packages and feeds
+        # Configure the continia feed twice for the same package id to test deduplication across multiple feeds
+        $bcContainerHelperConfig.TrustedNuGetFeeds = @(
+            @{ "url" = "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/AppSourceSymbols/nuget/v3/index.json" },
+            @{ "url" = "https://pkgs.dev.azure.com/continia-repository/ContiniaBCPublicFeeds/_packaging/AppSourceApps/nuget/v3/index.json" },
+            @{ "url" = "https://pkgs.dev.azure.com/continia-repository/ContiniaBCPublicFeeds/_packaging/AppSourceApps/nuget/v3/index.json" }
+        )
+    }
+
+    It 'Find-BcNuGetPackage returns deduplicated results in ascending order across multiple feeds' {
+        # Capture Information stream (Write-Host) alongside the result to verify both feeds were searched
+        $allOutput = @(Find-BcNuGetPackage -packageName "6da8dd2f-e698-461f-9147-8e404244dd85" -version '0.0.0.0' -select AllAscending -allowPrerelease 6>&1)
+        $result = @($allOutput | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] })
+        $infoOutput = ($allOutput | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }) -join "`n"
+
+        # Verify both feeds were actually searched (matchingPackagesCount = 2 triggers deduplication)
+        $infoOutput | Should -BeLike '*Found 3 matching packages across all feeds*'
+
+        # Should have found more than one version
+        $result.Count | Should -BeGreaterThan 1
+
+        # No duplicate PackageId+PackageVersion entries after deduplication
+        $uniqueKeys = @($result | ForEach-Object { "$($_.PackageId)|$($_.PackageVersion)" } | Select-Object -Unique)
+        $uniqueKeys.Count | Should -Be $result.Count
+
+        # Both unique feeds should be represented in the results once
+        $uniqueFeeds = @($result | ForEach-Object { "$($_.Feed.Url)" } | Select-Object -Unique)
+        $uniqueFeeds.Count | Should -Be 2
+
+        # Versions should be in ascending order
+        for ($i = 0; $i -lt $result.Count - 1; $i++) {
+            $v1 = ($result[$i].PackageVersion -replace '-.+$') -as [System.Version]
+            $v2 = ($result[$i + 1].PackageVersion -replace '-.+$') -as [System.Version]
+            $v1 | Should -BeLessOrEqual $v2
+        }
+    }
+
+    It 'Find-BcNuGetPackage returns deduplicated results in descending order across multiple feeds' {
+        # Capture Information stream (Write-Host) alongside the result to verify both feeds were searched
+        $allOutput = @(Find-BcNuGetPackage -packageName "6da8dd2f-e698-461f-9147-8e404244dd85" -version '0.0.0.0' -select AllDescending -allowPrerelease 6>&1)
+        $result = @($allOutput | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] })
+        $infoOutput = ($allOutput | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }) -join "`n"
+
+        # Verify both feeds were actually searched (matchingPackagesCount = 2 triggers deduplication)
+        $infoOutput | Should -BeLike '*Found 3 matching packages across all feeds*'
+
+        # Should have found more than one version
+        $result.Count | Should -BeGreaterThan 1
+
+        # No duplicate PackageId+PackageVersion entries after deduplication
+        $uniqueKeys = @($result | ForEach-Object { "$($_.PackageId)|$($_.PackageVersion)" } | Select-Object -Unique)
+        $uniqueKeys.Count | Should -Be $result.Count
+
+        # Both unique feeds should be represented in the results once
+        $uniqueFeeds = @($result | ForEach-Object { "$($_.Feed.Url)" } | Select-Object -Unique)
+        $uniqueFeeds.Count | Should -Be 2
+
+        # Versions should be in descending order
+        for ($i = 0; $i -lt $result.Count - 1; $i++) {
+            $v1 = ($result[$i].PackageVersion -replace '-.+$') -as [System.Version]
+            $v2 = ($result[$i + 1].PackageVersion -replace '-.+$') -as [System.Version]
+            $v1 | Should -BeGreaterOrEqual $v2
+        }
     }
 }

--- a/NuGet/Find-BcNuGetPackage.ps1
+++ b/NuGet/Find-BcNuGetPackage.ps1
@@ -1,4 +1,4 @@
-<# 
+<#
  .Synopsis
   PROOF OF CONCEPT PREVIEW: Get Business Central NuGet Package from NuGet Server
  .Description
@@ -55,6 +55,7 @@ Function Find-BcNuGetPackage {
 
     $returnValue = @()
     $bestmatch = $null
+    $packageCount = 0
     # Search all trusted feeds for the package
     foreach($feed in (@([PSCustomObject]@{ "Url" = $nuGetServerUrl; "Token" = $nuGetToken; "Patterns" = @('*'); "Fingerprints" = @() })+$bcContainerHelperConfig.TrustedNuGetFeeds)) {
         if ($feed -and $feed.Url) {
@@ -74,11 +75,12 @@ Function Find-BcNuGetPackage {
                         Write-Host "No package found matching version '$version' for package id $($packageId)"
                         continue
                     }
+                    $packageCount++
                     $packageVersions = $packageVersionsStr.Split(',')
                     foreach($packageVersion in $packageVersions.Split(',')) {
                         if ($bestmatch) {
                             # We already have a match, check if this is a better match
-                            if (($select -eq 'Earliest' -and ([NuGetFeed]::CompareVersions($packageVersion, $bestmatch.PackageVersion) -eq -1)) -or 
+                            if (($select -eq 'Earliest' -and ([NuGetFeed]::CompareVersions($packageVersion, $bestmatch.PackageVersion) -eq -1)) -or
                                 ($select -eq 'Latest' -and ([NuGetFeed]::CompareVersions($packageVersion, $bestmatch.PackageVersion) -eq 1))) {
                                 $bestmatch = [PSCustomObject]@{
                                     "Feed" = $nuGetFeed
@@ -132,6 +134,13 @@ Function Find-BcNuGetPackage {
         return $bestmatch.Feed, $bestmatch.PackageId, $bestmatch.PackageVersion
     }
     else {
+        if ($packageCount -gt 1) {
+            # Deduplicate by PackageId and PackageVersion across all feeds
+            $packageVersionsHashSet = [System.Collections.Generic.HashSet[string]]::new()
+            $returnValue = @($returnValue | Where-Object { $packageVersionsHashSet.Add("$($_.PackageId)|$($_.PackageVersion)") })
+            # Sort all versions across all feeds and packages
+            $returnValue = @($returnValue | Sort-Object { ($_.PackageVersion -replace '-.+$') -as [System.Version]  }, { "$($_.PackageVersion)z" } -Descending:($select -eq 'AllDescending'))
+        }
         return $returnValue
     }
 }

--- a/NuGet/Find-BcNuGetPackage.ps1
+++ b/NuGet/Find-BcNuGetPackage.ps1
@@ -55,7 +55,7 @@ Function Find-BcNuGetPackage {
 
     $returnValue = @()
     $bestmatch = $null
-    $packageCount = 0
+    $matchingPackagesCount = 0
     # Search all trusted feeds for the package
     foreach($feed in (@([PSCustomObject]@{ "Url" = $nuGetServerUrl; "Token" = $nuGetToken; "Patterns" = @('*'); "Fingerprints" = @() })+$bcContainerHelperConfig.TrustedNuGetFeeds)) {
         if ($feed -and $feed.Url) {
@@ -75,7 +75,7 @@ Function Find-BcNuGetPackage {
                         Write-Host "No package found matching version '$version' for package id $($packageId)"
                         continue
                     }
-                    $packageCount++
+                    $matchingPackagesCount++
                     $packageVersions = $packageVersionsStr.Split(',')
                     foreach($packageVersion in $packageVersions.Split(',')) {
                         if ($bestmatch) {
@@ -134,12 +134,18 @@ Function Find-BcNuGetPackage {
         return $bestmatch.Feed, $bestmatch.PackageId, $bestmatch.PackageVersion
     }
     else {
-        if ($packageCount -gt 1) {
+        if ($matchingPackagesCount -gt 1) {
+            Write-Host "Found $matchingPackagesCount matching packages across all feeds"
+
             # Deduplicate by PackageId and PackageVersion across all feeds
-            $packageVersionsHashSet = [System.Collections.Generic.HashSet[string]]::new()
-            $returnValue = @($returnValue | Where-Object { $packageVersionsHashSet.Add("$($_.PackageId)|$($_.PackageVersion)") })
-            # Sort all versions across all feeds and packages
-            $returnValue = @($returnValue | Sort-Object { ($_.PackageVersion -replace '-.+$') -as [System.Version]  }, { "$($_.PackageVersion)z" } -Descending:($select -eq 'AllDescending'))
+            Write-Host "Deduplicating by PackageId and PackageVersion across all feeds"
+            $returnValue = @($returnValue | Sort-Object { "$($_.PackageId)|$($_.PackageVersion)" } -Unique)
+
+            if ($select -eq 'AllAscending' -or $select -eq 'AllDescending') {
+                # Sort all versions across all feeds and packages
+                Write-Host "Sorting all versions across all feeds and packages"
+                $returnValue = @($returnValue | Sort-Object { ($_.PackageVersion -replace '-.+$') -as [System.Version]  }, { "$($_.PackageVersion)z" } -Descending:($select -eq 'AllDescending'))
+            }
         }
         return $returnValue
     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 6.1.16
+Issue 4060 Download-BcNuGetPackageToFolder downloads wrong version for "LatestMatching" and "EarliestMatching" for multiple matching packages
 Run-AlPipeline: Fix AS0054 by creating AppSourceCop.json (with mandatory affixes) for test/bcpt apps when enableCodeAnalyzersOnTestApps is set
 
 6.1.15

--- a/Tests/NuGet.Tests.ps1
+++ b/Tests/NuGet.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
 }
 
 AfterAll {
-    
+
 }
 
 Describe 'Download' {
@@ -23,5 +23,73 @@ Describe 'Download' {
 
         $files = @(Get-ChildItem $folder)
         $files.Count | Should -Be 6
+    }
+}
+
+Describe 'Find-BcNuGetPackage' {
+    BeforeEach {
+        # Configure the app source feed and continia feed for different package ids to test sorting accross multiple packages and feeds
+        # Configure the continia feed twice for the same package id to test deduplication across multiple feeds
+        $bcContainerHelperConfig.TrustedNuGetFeeds = @(
+            @{ "url" = "https://dynamicssmb2.pkgs.visualstudio.com/DynamicsBCPublicFeeds/_packaging/AppSourceSymbols/nuget/v3/index.json" },
+            @{ "url" = "https://pkgs.dev.azure.com/continia-repository/ContiniaBCPublicFeeds/_packaging/AppSourceApps/nuget/v3/index.json" },
+            @{ "url" = "https://pkgs.dev.azure.com/continia-repository/ContiniaBCPublicFeeds/_packaging/AppSourceApps/nuget/v3/index.json" }
+        )
+    }
+
+    It 'Find-BcNuGetPackage returns deduplicated results in ascending order across multiple feeds' {
+        # Capture Information stream (Write-Host) alongside the result to verify both feeds were searched
+        $allOutput = @(Find-BcNuGetPackage -packageName "6da8dd2f-e698-461f-9147-8e404244dd85" -version '0.0.0.0' -select AllAscending -allowPrerelease 6>&1)
+        $result = @($allOutput | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] })
+        $infoOutput = ($allOutput | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }) -join "`n"
+
+        # Verify both feeds were actually searched (matchingPackagesCount = 2 triggers deduplication)
+        $infoOutput | Should -BeLike '*Found 3 matching packages across all feeds*'
+
+        # Should have found more than one version
+        $result.Count | Should -BeGreaterThan 1
+
+        # No duplicate PackageId+PackageVersion entries after deduplication
+        $uniqueKeys = @($result | ForEach-Object { "$($_.PackageId)|$($_.PackageVersion)" } | Select-Object -Unique)
+        $uniqueKeys.Count | Should -Be $result.Count
+
+        # Both unique feeds should be represented in the results once
+        $uniqueFeeds = @($result | ForEach-Object { "$($_.Feed.Url)" } | Select-Object -Unique)
+        $uniqueFeeds.Count | Should -Be 2
+
+        # Versions should be in ascending order
+        for ($i = 0; $i -lt $result.Count - 1; $i++) {
+            $v1 = ($result[$i].PackageVersion -replace '-.+$') -as [System.Version]
+            $v2 = ($result[$i + 1].PackageVersion -replace '-.+$') -as [System.Version]
+            $v1 | Should -BeLessOrEqual $v2
+        }
+    }
+
+    It 'Find-BcNuGetPackage returns deduplicated results in descending order across multiple feeds' {
+        # Capture Information stream (Write-Host) alongside the result to verify both feeds were searched
+        $allOutput = @(Find-BcNuGetPackage -packageName "6da8dd2f-e698-461f-9147-8e404244dd85" -version '0.0.0.0' -select AllDescending -allowPrerelease 6>&1)
+        $result = @($allOutput | Where-Object { $_ -isnot [System.Management.Automation.InformationRecord] })
+        $infoOutput = ($allOutput | Where-Object { $_ -is [System.Management.Automation.InformationRecord] }) -join "`n"
+
+        # Verify both feeds were actually searched (matchingPackagesCount = 2 triggers deduplication)
+        $infoOutput | Should -BeLike '*Found 3 matching packages across all feeds*'
+
+        # Should have found more than one version
+        $result.Count | Should -BeGreaterThan 1
+
+        # No duplicate PackageId+PackageVersion entries after deduplication
+        $uniqueKeys = @($result | ForEach-Object { "$($_.PackageId)|$($_.PackageVersion)" } | Select-Object -Unique)
+        $uniqueKeys.Count | Should -Be $result.Count
+
+        # Both unique feeds should be represented in the results once
+        $uniqueFeeds = @($result | ForEach-Object { "$($_.Feed.Url)" } | Select-Object -Unique)
+        $uniqueFeeds.Count | Should -Be 2
+
+        # Versions should be in descending order
+        for ($i = 0; $i -lt $result.Count - 1; $i++) {
+            $v1 = ($result[$i].PackageVersion -replace '-.+$') -as [System.Version]
+            $v2 = ($result[$i + 1].PackageVersion -replace '-.+$') -as [System.Version]
+            $v1 | Should -BeGreaterOrEqual $v2
+        }
     }
 }


### PR DESCRIPTION
### ❔What, Why & How

The function `Find-BcNuGetPackage` did not return the found package versions in the correct order for `AllAscending` and `AllDescending`, if the function found multiple packages accross all feeds.
This resulted in function `Download-BcNuGetPackageToFolder` to only find the `EarliestMatching` or `LatestMatching` version of the first found package instead of all packages, because this function expects the returned versions to already be sorted correctly.

With this pull request the function `Find-BcNuGetPackage` now sorts all found package versions as exepcted, but only if multiple packages were found.

Additionally this pull request adds a deduplication based on the package id and version, because each package with the same package id/name in different feeds could contain the same versions multiple times and only one of each version should be required.

Related to issue: #4060

### ✅ Checklist

- [x] Add tests (`Tests` / `LinuxTests`)
- [x] Update ReleaseNotes.txt
