### PR TITLE
Revert "Fix AS0054 when AppSourceCop runs on test apps (#4163)"

### DIFF
--- a/AppHandling/Run-AlPipeline.ps1
+++ b/AppHandling/Run-AlPipeline.ps1
@@ -2348,7 +2348,7 @@ Write-Host -ForegroundColor Yellow @'
         }
     }
 
-    if ($enableAppSourceCop -and ($app -or $enableCodeAnalyzersOnTestApps)) {
+    if ($enableAppSourceCop -and $app) {
         $appSourceCopJson = @{}
         $saveit = $false
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 6.1.16
 Issue 4060 Download-BcNuGetPackageToFolder downloads wrong version for "LatestMatching" and "EarliestMatching" for multiple matching packages
-Run-AlPipeline: Fix AS0054 by creating AppSourceCop.json (with mandatory affixes) for test/bcpt apps when enableCodeAnalyzersOnTestApps is set
+Run-AlPipeline: Revert generating AppSourceCop.json for test/bcpt apps when enableCodeAnalyzersOnTestApps is set (reverts #4163) - it enforced mandatory-affix rules on test apps and broke existing builds
 Fix error when extracting apps whit paths that differ only in their casing
 
 6.1.15

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,5 @@
 6.1.16
 Issue 4060 Download-BcNuGetPackageToFolder downloads wrong version for "LatestMatching" and "EarliestMatching" for multiple matching packages
-Run-AlPipeline: Revert generating AppSourceCop.json for test/bcpt apps when enableCodeAnalyzersOnTestApps is set (reverts #4163) - it enforced mandatory-affix rules on test apps and broke existing builds
 Fix error when extracting apps whit paths that differ only in their casing
 
 6.1.15


### PR DESCRIPTION
## ❔What, Why & How

Reverts #4163 (commit 82e0c0047974ad79c6980a3a135f853ef92d91f6).

That change altered the condition in `Run-AlPipeline.ps1` that controls generation of `AppSourceCop.json` from:

```powershell
if ($enableAppSourceCop -and $app) {
```

to:

```powershell
if ($enableAppSourceCop -and ($app -or $enableCodeAnalyzersOnTestApps)) {
```

As a result, when a repo has **both** `enableAppSourceCop=true` **and** `enableCodeAnalyzersOnTestApps=true`, `AppSourceCop.json` (with mandatory affixes/prefix) is now generated and enforced on test/bcpt apps as well as regular apps.

This shipped in BcContainerHelper 6.1.16-preview and broke `microsoft/BCApps` CI: test apps started failing compilation with affix rule `AA0215` (e.g. `The file PeppolTest.Codeunit.al has an incorrect name. The valid name is ForNAVPeppolTest.Codeunit.al`), across all release branches, because pre-existing test app code doesn't conform to the mandatory-affix naming rules.

This PR reverts the functional change back to the original condition and removes/updates the corresponding `ReleaseNotes.txt` entry.

The underlying AS0054 issue (AppSourceCop analyzer enabled on test apps without an `AppSourceCop.json`) will need a different fix — one that doesn't enforce mandatory-affix rules on pre-existing, non-compliant test app code.

## ✅ Checklist

- [x] Update ReleaseNotes.txt