### PR TITLE
Switch back to PSSessions for BC29

### DIFF
--- a/ContainerHandling/Invoke-ScriptInNavContainer.ps1
+++ b/ContainerHandling/Invoke-ScriptInNavContainer.ps1
@@ -35,7 +35,7 @@ function Invoke-ScriptInBcContainer {
     if ($useSession -and $usePwsh) {
         # Check if we should disable PS sessions for BC v28+ due to known PS7 remote session issues
         # https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/upgrade/known-issues#business-central-admin-shell-modules-fail-in-powershell7-remote-sessions
-        if ($platformVersion.Major -ge 28 -and -not $bcContainerHelperConfig.usePsSessionForBc28) {
+        if ($platformVersion.Major -eq 28 -and -not $bcContainerHelperConfig.usePsSessionForBc28) {
             $useSession = $false
         }
     }


### PR DESCRIPTION
### ❔What, Why & How

<!-- Include description of the changes that will help reviewers in their task -->

Related to this previous PR https://github.com/microsoft/navcontainerhelper/pull/4115

With BC28 we saw a break in creating PSSessions. This should be fixed with BC29 so we should go back to the "normal" behavior in BCCH where we create PSSessions when possible.  

Prerequisite: Merge this one first https://github.com/microsoft/nav-docker/pull/615

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [ ] Update ReleaseNotes.txt
- [ ] Add telemetry

<!-- Include more checklist entries, if needed -->
