### PR TITLE
Request default delegated scopes instead of user_impersonation

### DIFF
--- a/Auth/New-BcAuthContext.ps1
+++ b/Auth/New-BcAuthContext.ps1
@@ -149,7 +149,7 @@ try {
     }
     else {
         if ($scopes.EndsWith('/')) {
-            $scopes += "user_impersonation offline_access"
+            $scopes += ".default offline_access"
         }
 
         if ($credential) {


### PR DESCRIPTION
### ❔What, Why & How

Update `New-BcAuthContext` to request `<resource>/.default offline_access` instead of assuming every resource exposes a `user_impersonation` scope.

The existing behavior fails for the Business Central API when using the well-known PowerShell client application because that client is not preauthorized for the legacy `user_impersonation` scope.

Using `.default` allows Microsoft Entra ID to issue the delegated permissions already configured and consented for the selected client and resource. This also preserves compatibility with custom client and resource application IDs.

Related to issue: #4183 
