### PR TITLE
Fix AppSource upload failing on Front Door SAS URIs

### DIFF
--- a/AppSource/Invoke-IngestionAPI.ps1
+++ b/AppSource/Invoke-IngestionAPI.ps1
@@ -38,7 +38,9 @@ function Invoke-IngestionApiRestMethod {
     }
     if ($PSBoundParameters.ContainsKey('body')) {
         if (!$silent) {
-            $body | Out-Host
+            # Strip URL query strings before logging the body so that SAS tokens
+            # (e.g. in package fileSasUri values) are never written to logs.
+            [regex]::Replace($body, '(?i)(https?://[^\s"''?]+)\?[^\s"'']*', '$1?<redacted>') | Out-Host
         }
         $parameters += @{
             "body" = [System.Text.Encoding]::UTF8.GetBytes($body)

--- a/AppSource/New-AppSourceSubmission.ps1
+++ b/AppSource/New-AppSourceSubmission.ps1
@@ -146,13 +146,18 @@ try {
             $packageUpload = Invoke-IngestionApiPost -authContext $authContext -path "/products/$productId/packages" -Body $body -silent:($silent.IsPresent)
         
             # Upload the package to the SAS URI returned by the Ingestion API.
-            # Primary path uses the Az.Storage cmdlets (reconstructing the storage
-            # account endpoint from the SAS URI). If that fails - e.g. when the
-            # Ingestion API returns a SAS URI on a host that isn't a plain
-            # <account>.blob.core.windows.net endpoint (such as an Azure Front Door
-            # host like *.azurefd.net) - fall back to uploading the bytes directly
-            # to the SAS URI as-issued (see issue #4191).
+            # Primary path uploads the bytes directly to the SAS URI as-issued,
+            # which works regardless of the host (e.g. an Azure Front Door host
+            # like *.azurefd.net, see issue #4191). If that fails, fall back to
+            # the legacy Az.Storage upload (which reconstructs the storage account
+            # endpoint from the SAS URI - only valid for <account>.blob.core.windows.net hosts).
             try {
+                Invoke-RestMethod -Method Put -Uri $packageUpload.fileSasUri -InFile $file -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -ContentType 'application/octet-stream' | Out-Null
+            }
+            catch {
+                if (!$silent) {
+                    Write-Host -ForegroundColor Yellow "WARNING: Direct upload to the SAS URI failed ($($_.Exception.Message.Trim())). Falling back to the Az.Storage upload."
+                }
                 $uri = [System.Uri] $packageUpload.fileSasUri
                 $storageAccountName = $uri.DnsSafeHost.Split(".")[0]
                 $container = $uri.LocalPath.Substring(1).split('/')[0]
@@ -166,12 +171,6 @@ try {
 
                 $storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -SasToken $sasToken
                 Set-AzureStorageBlobContent -File $file -Container $container -Blob $blobname -Context $storageContext -Force | Out-Null
-            }
-            catch {
-                if (!$silent) {
-                    Write-Host -ForegroundColor Yellow "WARNING: Uploading through Az.Storage failed ($($_.Exception.Message.Trim())). Falling back to a direct upload to the SAS URI."
-                }
-                Invoke-RestMethod -Method Put -Uri $packageUpload.fileSasUri -InFile $file -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -ContentType 'application/octet-stream' | Out-Null
             }
         
             $packageUpload.state = "Uploaded"

--- a/AppSource/New-AppSourceSubmission.ps1
+++ b/AppSource/New-AppSourceSubmission.ps1
@@ -145,19 +145,34 @@ try {
             }
             $packageUpload = Invoke-IngestionApiPost -authContext $authContext -path "/products/$productId/packages" -Body $body -silent:($silent.IsPresent)
         
-            $uri = [System.Uri] $packageUpload.fileSasUri
-            $storageAccountName = $uri.DnsSafeHost.Split(".")[0]
-            $container = $uri.LocalPath.Substring(1).split('/')[0]
-            $blobname = $uri.LocalPath.Substring(1).split('/')[1]
-            $sasToken = $uri.Query
+            # Upload the package to the SAS URI returned by the Ingestion API.
+            # Primary path uses the Az.Storage cmdlets (reconstructing the storage
+            # account endpoint from the SAS URI). If that fails - e.g. when the
+            # Ingestion API returns a SAS URI on a host that isn't a plain
+            # <account>.blob.core.windows.net endpoint (such as an Azure Front Door
+            # host like *.azurefd.net) - fall back to uploading the bytes directly
+            # to the SAS URI as-issued (see issue #4191).
+            try {
+                $uri = [System.Uri] $packageUpload.fileSasUri
+                $storageAccountName = $uri.DnsSafeHost.Split(".")[0]
+                $container = $uri.LocalPath.Substring(1).split('/')[0]
+                $blobname = $uri.LocalPath.Substring(1).split('/')[1]
+                $sasToken = $uri.Query
 
-            if (!(get-command New-AzureStorageContext -ErrorAction SilentlyContinue)) {
-                Set-Alias -Name New-AzureStorageContext -Value New-AzStorageContext
-                Set-Alias -Name Set-AzureStorageBlobContent -Value Set-AzStorageBlobContent
+                if (!(get-command New-AzureStorageContext -ErrorAction SilentlyContinue)) {
+                    Set-Alias -Name New-AzureStorageContext -Value New-AzStorageContext
+                    Set-Alias -Name Set-AzureStorageBlobContent -Value Set-AzStorageBlobContent
+                }
+
+                $storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -SasToken $sasToken
+                Set-AzureStorageBlobContent -File $file -Container $container -Blob $blobname -Context $storageContext -Force | Out-Null
             }
-
-            $storageContext = New-AzureStorageContext -StorageAccountName $storageAccountName -SasToken $sasToken
-            Set-AzureStorageBlobContent -File $file -Container $container -Blob $blobname -Context $storageContext -Force | Out-Null
+            catch {
+                if (!$silent) {
+                    Write-Host -ForegroundColor Yellow "WARNING: Uploading through Az.Storage failed ($($_.Exception.Message.Trim())). Falling back to a direct upload to the SAS URI."
+                }
+                Invoke-RestMethod -Method Put -Uri $packageUpload.fileSasUri -InFile $file -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -ContentType 'application/octet-stream' | Out-Null
+            }
         
             $packageUpload.state = "Uploaded"
             $packageUploaded = Invoke-IngestionApiPut -authContext $authContext -path "/products/$productId/packages/$($packageUpload.id)" -Body ($packageUpload | ConvertTo-HashTable) -silent:($silent.IsPresent)

--- a/AppSource/New-AppSourceSubmission.ps1
+++ b/AppSource/New-AppSourceSubmission.ps1
@@ -145,12 +145,8 @@ try {
             }
             $packageUpload = Invoke-IngestionApiPost -authContext $authContext -path "/products/$productId/packages" -Body $body -silent:($silent.IsPresent)
         
-            # Upload the package to the SAS URI returned by the Ingestion API.
-            # Primary path uploads the bytes directly to the SAS URI as-issued,
-            # which works regardless of the host (e.g. an Azure Front Door host
-            # like *.azurefd.net, see issue #4191). If that fails, fall back to
-            # the legacy Az.Storage upload (which reconstructs the storage account
-            # endpoint from the SAS URI - only valid for <account>.blob.core.windows.net hosts).
+            # Upload directly to the SAS URI as-issued (works for any host, e.g. Azure Front Door - see issue #4191).
+            # Fall back to the legacy Az.Storage upload (only valid for <account>.blob.core.windows.net hosts) if that fails.
             try {
                 Invoke-RestMethod -Method Put -Uri $packageUpload.fileSasUri -InFile $file -Headers @{ 'x-ms-blob-type' = 'BlockBlob' } -ContentType 'application/octet-stream' | Out-Null
             }


### PR DESCRIPTION
## Why

`New-AppSourceSubmission` started failing for everyone with:

```
Set-AzureStorageBlobContent : The remote name could not be resolved: 'workloadfilewus2-...blob.core.windows.net'
```

Partner Center moved package uploads behind Azure Front Door, so the Ingestion API now returns `fileSasUri` values on `*.b02.azurefd.net` hosts instead of `<account>.blob.core.windows.net`. The upload code threw the SAS URI away and rebuilt a storage endpoint from the account label via `New-AzStorageContext -StorageAccountName`, producing a hostname that no longer resolves.

## What changed

**`New-AppSourceSubmission.ps1` - upload directly to the SAS URI.**
The package bytes are now PUT straight to `fileSasUri` as issued (a Block Blob `PUT`), which works for any host the API hands out (old blob endpoints and the new Front Door ones). The legacy `Az.Storage` upload is kept as a fallback if the direct PUT fails. Making the direct upload the primary path also removes the slow DNS/retry stall that happened when Az.Storage was tried first against the dead reconstructed host.

## Validation

Verified end to end against a real product (BingMaps.AppSource) via AL-Go delivery: both the main app and the library package uploaded successfully (the submission reached preview scope), across two different Front Door regions (eus2 and wus2) in a single submission. 

Fixes: #4191