### PR TITLE
Fix Backup-BcContainerDatabases failing on BC29 multitenant containers

### DIFF
--- a/Bacpac/Backup-NavContainerDatabases.ps1
+++ b/Bacpac/Backup-NavContainerDatabases.ps1
@@ -99,12 +99,13 @@ try {
             }
             Backup -ServerInstance $databaseServerInstance -database $DatabaseName -bakFolder $bakFolder -bakName "app" -databasecredential $databasecredential -compress:$compress
             $tenant | ForEach-Object {
-                $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance $_ -ErrorAction SilentlyContinue
+                $tenantInfo = $null
+                try { $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance $_ -ErrorAction SilentlyContinue } catch { }
                 if ($tenantInfo) {
                     $dbName = $tenantInfo.DatabaseName
                 }
                 else {
-                    $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance default -ErrorAction SilentlyContinue
+                    try { $tenantInfo = Get-NAVTenant -ServerInstance $serverInstance default -ErrorAction SilentlyContinue } catch { $tenantInfo = $null }
                     if ($tenantInfo) {
                         $dbName = $tenantInfo.DatabaseName.replace('default',$_)
                     }

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,5 @@
 6.1.18
-
+Issue 4186 Backup-BcContainerDatabases fails on BC29 multitenant containers ('The tenant ''tenant'' is not mounted or does not exist.')
 6.1.17
 Fix AppSource upload failing on Front Door SAS URIs
 BC29 moved dll to Admin folder


### PR DESCRIPTION
### ❔What, Why & How

`Backup-BcContainerDatabases` aborts on BC29 multitenant containers with `The tenant 'tenant' is not mounted or does not exist.`, after `app.bak` and `default.bak` are already written but before the `tenant` template database is backed up. This breaks backup pipelines on BC29 while the exact same code works on BC28 and earlier.

**Root cause:** For multitenant containers the function always appends the literal `tenant` (the unmounted template database that ships in the image) to the tenant list, then resolves each entry via `Get-NAVTenant -ServerInstance $serverInstance $_ -ErrorAction SilentlyContinue`. In BC29 the management cmdlets were re-implemented on the V3 REST management API, so `Get-NAVTenant` now emits a terminating error when a tenant is not mounted or does not exist, instead of quietly returning nothing as it did on BC28. The container script host runs with `$ErrorActionPreference = 'Stop'`, which turns that error into a terminating one that `-ErrorAction SilentlyContinue` does not suppress, so the lookup for `tenant` throws and the whole backup aborts before the existing fallback (which derives the database name and backs it up) can run.

**Fix:** Wrap the two `Get-NAVTenant` lookups in `try/catch` so a terminating "not mounted / does not exist" error is tolerated and the existing fallback logic runs, exactly as it did pre-BC29. This is execution-path independent (works whether the cmdlet returns empty on BC28 or throws on BC29, and regardless of `useSession`/admin/`$ErrorActionPreference`).

Verified end to end by running the patched module against both a BC28 and a BC29 multitenant container: both now produce `app.bak`, `default.bak` and `tenant.bak` successfully.

Related to issue: #4186

### ✅ Checklist

- [ ] Add tests (`Tests` / `LinuxTests`)
- [x] Update ReleaseNotes.txt
- [ ] Add telemetry